### PR TITLE
feat: Add macOS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
 
     steps:
@@ -56,16 +56,74 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: toasty-signed
+          name: toasty-windows
           path: artifacts/*.exe
 
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build x64 (Intel)
+        run: |
+          clang++ -std=c++20 -x objective-c++ \
+            -target x86_64-apple-macos10.15 \
+            -framework Foundation -framework AppKit \
+            -O2 -o toasty-x64 main_mac.mm
+
+      - name: Build ARM64 (Apple Silicon)
+        run: |
+          clang++ -std=c++20 -x objective-c++ \
+            -target arm64-apple-macos11 \
+            -framework Foundation -framework AppKit \
+            -O2 -o toasty-arm64 main_mac.mm
+
+      - name: Create Universal Binary
+        run: |
+          lipo -create -output toasty toasty-x64 toasty-arm64
+          file toasty
+
+      - name: Prepare release artifacts
+        run: |
+          mkdir -p artifacts
+          cp toasty artifacts/toasty-macos
+          cp toasty-x64 artifacts/toasty-macos-x64
+          cp toasty-arm64 artifacts/toasty-macos-arm64
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: toasty-macos
+          path: artifacts/toasty-macos*
+
+  release:
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: toasty-windows
+          path: artifacts
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: toasty-macos
+          path: artifacts
+
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           files: |
             artifacts/toasty-x64.exe
             artifacts/toasty-arm64.exe
+            artifacts/toasty-macos
+            artifacts/toasty-macos-x64
+            artifacts/toasty-macos-arm64
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,57 @@ project(toasty LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Use static runtime for standalone exe
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+if(WIN32)
+    # Windows build
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    
+    add_executable(toasty main.cpp resource.rc)
+    
+    target_link_libraries(toasty PRIVATE
+        windowsapp
+        runtimeobject
+        shlwapi
+        shell32
+        ole32
+        propsys
+    )
+    
+    target_compile_options(toasty PRIVATE
+        $<$<CONFIG:Release>:/O1 /GL>
+    )
+    target_link_options(toasty PRIVATE
+        $<$<CONFIG:Release>:/LTCG /OPT:REF /OPT:ICF>
+    )
 
-add_executable(toasty main.cpp resource.rc)
+elseif(APPLE)
+    # macOS build
+    enable_language(OBJCXX)
+    
+    add_executable(toasty main_mac.mm)
+    
+    # Find and link macOS frameworks
+    find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+    find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
+    find_library(USERNOTIFICATIONS_FRAMEWORK UserNotifications REQUIRED)
+    
+    target_link_libraries(toasty PRIVATE
+        ${FOUNDATION_FRAMEWORK}
+        ${APPKIT_FRAMEWORK}
+        ${USERNOTIFICATIONS_FRAMEWORK}
+    )
+    
+    # Copy icons to build directory
+    file(GLOB ICON_FILES "${CMAKE_SOURCE_DIR}/icons/*.png")
+    foreach(ICON ${ICON_FILES})
+        get_filename_component(ICON_NAME ${ICON} NAME)
+        configure_file(${ICON} ${CMAKE_BINARY_DIR}/icons/${ICON_NAME} COPYONLY)
+    endforeach()
+    
+    # Optimize for size in Release
+    target_compile_options(toasty PRIVATE
+        $<$<CONFIG:Release>:-Os>
+    )
 
-# Link Windows Runtime libraries
-target_link_libraries(toasty PRIVATE
-    windowsapp
-    runtimeobject
-    shlwapi
-    shell32
-    ole32
-    propsys
-)
-
-# Optimize for size in Release
-target_compile_options(toasty PRIVATE
-    $<$<CONFIG:Release>:/O1 /GL>
-)
-target_link_options(toasty PRIVATE
-    $<$<CONFIG:Release>:/LTCG /OPT:REF /OPT:ICF>
-)
+else()
+    message(FATAL_ERROR "Unsupported platform. Toasty supports Windows and macOS only.")
+endif()

--- a/README.md
+++ b/README.md
@@ -19,21 +19,27 @@ That's it. On Windows, Toasty auto-registers on first run.
 
 ### Windows
 
-Download `toasty.exe` from [Releases](../../releases) or build from source.
+Download `toasty-x64.exe` or `toasty-arm64.exe` from [Releases](../../releases).
 
 ### macOS
 
-1. **Install terminal-notifier** (required for notifications):
+1. **Download toasty** from [Releases](../../releases):
+   - `toasty-macos` - Universal binary (Intel + Apple Silicon)
+   - `toasty-macos-x64` - Intel Macs only
+   - `toasty-macos-arm64` - Apple Silicon only
+
+2. **Make it executable and move to PATH**:
+   ```bash
+   chmod +x toasty-macos
+   sudo mv toasty-macos /usr/local/bin/toasty
+   ```
+
+3. **Install terminal-notifier** (required for notifications):
    ```bash
    brew install terminal-notifier
    ```
 
-2. **Build toasty**:
-   ```bash
-   clang++ -std=c++20 -x objective-c++ -framework Foundation -framework AppKit -o toasty main_mac.mm
-   ```
-
-3. **Enable notifications**:
+4. **Enable notifications**:
    - Open **System Settings → Notifications**
    - Find **terminal-notifier** in the list
    - Enable **Allow Notifications**

--- a/README.md
+++ b/README.md
@@ -2,15 +2,47 @@
 
 <img src="icons/toasty.png" alt="Toasty mascot" width="128" align="right">
 
-A tiny Windows toast notification CLI that knows how to hook into Coding Agents so you get notified when their long running tasks are finished. 229 KB, no dependencies.
+A tiny toast notification CLI for **Windows** and **macOS** that hooks into Coding Agents so you get notified when their long running tasks are finished.
+
+- **Windows**: 229 KB, no dependencies
+- **macOS**: Requires `terminal-notifier` (installable via Homebrew)
 
 ## Quick Start
 
-```cmd
+```bash
 toasty "Hello World" -t "Toasty"
 ```
 
-That's it. Toasty auto-registers on first run.
+That's it. On Windows, Toasty auto-registers on first run.
+
+## Installation
+
+### Windows
+
+Download `toasty.exe` from [Releases](../../releases) or build from source.
+
+### macOS
+
+1. **Install terminal-notifier** (required for notifications):
+   ```bash
+   brew install terminal-notifier
+   ```
+
+2. **Build toasty**:
+   ```bash
+   clang++ -std=c++20 -x objective-c++ -framework Foundation -framework AppKit -o toasty main_mac.mm
+   ```
+
+3. **Enable notifications**:
+   - Open **System Settings → Notifications**
+   - Find **terminal-notifier** in the list
+   - Enable **Allow Notifications**
+   - Set notification style to **Banners** or **Alerts**
+
+   > **Note**: If terminal-notifier doesn't appear in the list, run it once:
+   > ```bash
+   > open /opt/homebrew/Cellar/terminal-notifier/*/terminal-notifier.app
+   > ```
 
 ## Usage
 
@@ -50,7 +82,12 @@ Options:
 
 Toasty automatically detects when it's called from a known AI CLI tool and applies the appropriate icon and title. No flags needed!
 
-```cmd
+**Auto-detected tools:**
+- Claude Code
+- GitHub Copilot
+- Google Gemini CLI
+
+```bash
 # Called from Claude - automatically uses Claude preset
 toasty "Analysis complete"
 
@@ -62,7 +99,7 @@ toasty "Code review done"
 
 Override auto-detection with `--app`:
 
-```cmd
+```bash
 toasty "Processing finished" --app claude
 toasty "Build succeeded" --app copilot
 toasty "Query done" --app gemini
@@ -76,7 +113,7 @@ Toasty can automatically configure AI CLI agents to show notifications when task
 
 ### Auto-Install
 
-```cmd
+```bash
 # Install for all detected agents
 toasty --install
 
@@ -115,6 +152,7 @@ If you prefer to configure hooks manually:
 
 Add to `~/.claude/settings.json`:
 
+**Windows:**
 ```json
 {
   "hooks": {
@@ -133,10 +171,30 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
+**macOS:**
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/toasty \"Claude finished\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ### Gemini CLI
 
 Add to `~/.gemini/settings.json`:
 
+**Windows:**
 ```json
 {
   "hooks": {
@@ -146,6 +204,25 @@ Add to `~/.gemini/settings.json`:
           {
             "type": "command",
             "command": "C:\\path\\to\\toasty.exe \"Gemini finished\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**macOS:**
+```json
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/toasty \"Gemini finished\"",
             "timeout": 5000
           }
         ]
@@ -235,6 +312,8 @@ toasty --version
 
 ## Building
 
+### Windows
+
 Requires Visual Studio 2022 with C++ workload.
 
 ```cmd
@@ -243,6 +322,22 @@ cmake --build build --config Release
 ```
 
 Output: `build\Release\toasty.exe`
+
+### macOS
+
+Requires Xcode Command Line Tools.
+
+```bash
+clang++ -std=c++20 -x objective-c++ -framework Foundation -framework AppKit -o build/toasty main_mac.mm
+```
+
+Or with CMake:
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+Output: `build/toasty`
 
 ## Testing
 

--- a/main_mac.mm
+++ b/main_mac.mm
@@ -1,0 +1,697 @@
+// Toasty - macOS implementation
+// Native Objective-C++ for macOS notifications
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <UserNotifications/UserNotifications.h>
+#import <libproc.h>
+#import <sys/sysctl.h>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+// App presets for AI agents
+struct AppPreset {
+    std::string name;
+    std::string title;
+    std::string iconFile;
+};
+
+const AppPreset APP_PRESETS[] = {
+    { "claude", "Claude", "claude.png" },
+    { "copilot", "GitHub Copilot", "copilot.png" },
+    { "gemini", "Gemini", "gemini.png" },
+    { "codex", "Codex", "codex.png" },
+    { "cursor", "Cursor", "cursor.png" }
+};
+
+// Convert std::string to NSString
+NSString* toNSString(const std::string& str) {
+    return [NSString stringWithUTF8String:str.c_str()];
+}
+
+// Convert NSString to std::string
+std::string toString(NSString* nsstr) {
+    return nsstr ? [nsstr UTF8String] : "";
+}
+
+// Convert string to lowercase
+std::string toLower(std::string str) {
+    for (auto& c : str) c = tolower(c);
+    return str;
+}
+
+// Find preset by name (case-insensitive)
+const AppPreset* findPreset(const std::string& name) {
+    auto lowerName = toLower(name);
+    for (const auto& preset : APP_PRESETS) {
+        if (toLower(preset.name) == lowerName) {
+            return &preset;
+        }
+    }
+    return nullptr;
+}
+
+// Get executable path
+std::string getExePath() {
+    char path[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_pidpath(getpid(), path, sizeof(path)) > 0) {
+        return std::string(path);
+    }
+    return "";
+}
+
+// Get home directory
+std::string getHomeDir() {
+    return toString(NSHomeDirectory());
+}
+
+// Get icons directory (next to executable or in Resources)
+std::string getIconsDir() {
+    std::string exePath = getExePath();
+    fs::path exeDir = fs::path(exePath).parent_path();
+    
+    // Check for icons directory next to executable
+    fs::path iconsDir = exeDir / "icons";
+    if (fs::exists(iconsDir)) {
+        return iconsDir.string();
+    }
+    
+    // Check in Resources (for .app bundle)
+    fs::path resourcesDir = exeDir.parent_path() / "Resources" / "icons";
+    if (fs::exists(resourcesDir)) {
+        return resourcesDir.string();
+    }
+    
+    // Fallback to source directory icons
+    fs::path sourceIcons = exeDir.parent_path() / "icons";
+    if (fs::exists(sourceIcons)) {
+        return sourceIcons.string();
+    }
+    
+    return "";
+}
+
+// Get icon path for preset
+std::string getIconPath(const AppPreset* preset) {
+    if (!preset) return "";
+    
+    std::string iconsDir = getIconsDir();
+    if (iconsDir.empty()) return "";
+    
+    fs::path iconPath = fs::path(iconsDir) / preset->iconFile;
+    if (fs::exists(iconPath)) {
+        return iconPath.string();
+    }
+    return "";
+}
+
+// Get process name by PID
+std::string getProcessName(pid_t pid) {
+    char name[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_name(pid, name, sizeof(name)) > 0) {
+        return std::string(name);
+    }
+    return "";
+}
+
+// Get process path by PID
+std::string getProcessPath(pid_t pid) {
+    char path[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_pidpath(pid, path, sizeof(path)) > 0) {
+        return std::string(path);
+    }
+    return "";
+}
+
+// Get parent PID
+pid_t getParentPid(pid_t pid) {
+    struct kinfo_proc info;
+    size_t length = sizeof(info);
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
+    
+    if (sysctl(mib, 4, &info, &length, NULL, 0) == 0) {
+        return info.kp_eproc.e_ppid;
+    }
+    return 0;
+}
+
+// Check if process path contains a known CLI pattern
+const AppPreset* checkProcessForPreset(const std::string& path, const std::string& name) {
+    auto lowerPath = toLower(path);
+    auto lowerName = toLower(name);
+    
+    // Check for Gemini CLI
+    if (lowerPath.find("gemini-cli") != std::string::npos ||
+        lowerPath.find("gemini/cli") != std::string::npos ||
+        lowerPath.find("@google/gemini") != std::string::npos) {
+        return findPreset("gemini");
+    }
+    
+    // Check for Claude Code
+    if (lowerPath.find("claude-code") != std::string::npos ||
+        lowerPath.find("@anthropic") != std::string::npos ||
+        lowerName == "claude") {
+        return findPreset("claude");
+    }
+    
+    // Check for Cursor
+    if (lowerName.find("cursor") != std::string::npos) {
+        return findPreset("cursor");
+    }
+    
+    // Check for Copilot
+    if (lowerName == "copilot" || lowerPath.find("github-copilot") != std::string::npos) {
+        return findPreset("copilot");
+    }
+    
+    // Check for Codex
+    if (lowerName == "codex") {
+        return findPreset("codex");
+    }
+    
+    // Direct preset name match
+    return findPreset(lowerName);
+}
+
+// Walk up process tree to find a matching AI CLI preset
+const AppPreset* detectPresetFromAncestors(bool debug = false) {
+    pid_t currentPid = getpid();
+    
+    if (debug) {
+        std::cerr << "[DEBUG] Starting from PID: " << currentPid << "\n";
+    }
+    
+    // Walk up the process tree (max 20 levels)
+    for (int depth = 0; depth < 20; depth++) {
+        pid_t parentPid = getParentPid(currentPid);
+        
+        if (parentPid == 0 || parentPid == 1 || parentPid == currentPid) {
+            break; // Reached root or init
+        }
+        
+        std::string procName = getProcessName(parentPid);
+        std::string procPath = getProcessPath(parentPid);
+        
+        if (debug) {
+            std::cerr << "[DEBUG] Level " << depth << ": PID=" << parentPid
+                      << " Name=" << procName << "\n";
+            std::cerr << "[DEBUG]   Path: " << procPath << "\n";
+        }
+        
+        const AppPreset* preset = checkProcessForPreset(procPath, procName);
+        if (preset) {
+            if (debug) std::cerr << "[DEBUG] MATCH: " << preset->name << "\n";
+            return preset;
+        }
+        
+        currentPid = parentPid;
+    }
+    
+    return nullptr;
+}
+
+// Show notification using terminal-notifier (reliable on modern macOS)
+bool showNotification(const std::string& title, const std::string& message, const std::string& iconPath) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child process - detach from parent
+        setsid();
+        
+        // Try homebrew path first (Apple Silicon)
+        if (!iconPath.empty() && fs::exists(iconPath)) {
+            execl("/opt/homebrew/bin/terminal-notifier", "terminal-notifier",
+                  "-title", title.c_str(),
+                  "-message", message.c_str(),
+                  "-contentImage", iconPath.c_str(),
+                  "-sound", "default",
+                  nullptr);
+        } else {
+            execl("/opt/homebrew/bin/terminal-notifier", "terminal-notifier",
+                  "-title", title.c_str(),
+                  "-message", message.c_str(),
+                  "-sound", "default",
+                  nullptr);
+        }
+        // Try /usr/local/bin as fallback (Intel Macs)
+        if (!iconPath.empty() && fs::exists(iconPath)) {
+            execl("/usr/local/bin/terminal-notifier", "terminal-notifier",
+                  "-title", title.c_str(),
+                  "-message", message.c_str(),
+                  "-contentImage", iconPath.c_str(),
+                  "-sound", "default",
+                  nullptr);
+        } else {
+            execl("/usr/local/bin/terminal-notifier", "terminal-notifier",
+                  "-title", title.c_str(),
+                  "-message", message.c_str(),
+                  "-sound", "default",
+                  nullptr);
+        }
+        _exit(1);
+    }
+    
+    // Parent - don't wait, let child run independently  
+    return pid > 0;
+}
+
+// Escape special characters in JSON strings
+std::string escapeJsonString(const std::string& str) {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        switch (c) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result += c;
+        }
+    }
+    return result;
+}
+
+// Read file contents
+std::string readFile(const std::string& path) {
+    std::ifstream file(path);
+    if (!file) return "";
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+// Write file contents
+bool writeFile(const std::string& path, const std::string& content) {
+    std::ofstream file(path);
+    if (!file) return false;
+    file << content;
+    return file.good();
+}
+
+// Check if JSON contains toasty hook
+bool hasToastyHook(const std::string& jsonContent) {
+    return jsonContent.find("toasty") != std::string::npos;
+}
+
+// Claude Code hook installation
+bool isClaudeInstalled() {
+    std::string configPath = getHomeDir() + "/.claude/settings.json";
+    if (!fs::exists(configPath)) return false;
+    return hasToastyHook(readFile(configPath));
+}
+
+bool installClaude() {
+    std::string configDir = getHomeDir() + "/.claude";
+    std::string configPath = configDir + "/settings.json";
+    std::string exePath = getExePath();
+    
+    // Create directory if needed
+    fs::create_directories(configDir);
+    
+    std::string existingContent = readFile(configPath);
+    
+    // Build the hook command
+    std::string hookCmd = escapeJsonString(exePath) + " \\\"Task complete\\\" -t \\\"Claude Code\\\"";
+    
+    std::string hookJson = R"({
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ")" + hookCmd + R"(",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+})";
+    
+    if (existingContent.empty() || existingContent.find("hooks") == std::string::npos) {
+        return writeFile(configPath, hookJson);
+    }
+    
+    // TODO: Merge with existing hooks
+    std::cerr << "Claude settings.json already has hooks. Manual merge required.\n";
+    return false;
+}
+
+bool uninstallClaude() {
+    std::string configPath = getHomeDir() + "/.claude/settings.json";
+    if (!fs::exists(configPath)) return true;
+    
+    // TODO: Remove toasty hook from existing config
+    std::cerr << "Manual removal required from " << configPath << "\n";
+    return false;
+}
+
+// Gemini CLI hook installation
+bool isGeminiInstalled() {
+    std::string configPath = getHomeDir() + "/.gemini/settings.json";
+    if (!fs::exists(configPath)) return false;
+    return hasToastyHook(readFile(configPath));
+}
+
+bool installGemini() {
+    std::string configDir = getHomeDir() + "/.gemini";
+    std::string configPath = configDir + "/settings.json";
+    std::string exePath = getExePath();
+    
+    fs::create_directories(configDir);
+    
+    std::string existingContent = readFile(configPath);
+    
+    std::string hookCmd = escapeJsonString(exePath) + " \\\"Gemini finished\\\" -t \\\"Gemini\\\"";
+    
+    std::string hookJson = R"({
+  "hooks": {
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ")" + hookCmd + R"(",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+})";
+    
+    if (existingContent.empty() || existingContent.find("hooks") == std::string::npos) {
+        return writeFile(configPath, hookJson);
+    }
+    
+    std::cerr << "Gemini settings.json already has hooks. Manual merge required.\n";
+    return false;
+}
+
+bool uninstallGemini() {
+    std::string configPath = getHomeDir() + "/.gemini/settings.json";
+    if (!fs::exists(configPath)) return true;
+    std::cerr << "Manual removal required from " << configPath << "\n";
+    return false;
+}
+
+// GitHub Copilot hook installation (repo-local)
+bool isCopilotInstalled() {
+    return fs::exists(".github/hooks/toasty.json");
+}
+
+bool installCopilot() {
+    fs::create_directories(".github/hooks");
+    
+    std::string hookJson = R"({
+  "version": 1,
+  "hooks": {
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "toasty 'Copilot finished' -t 'GitHub Copilot'",
+        "timeoutSec": 5
+      }
+    ]
+  }
+})";
+    
+    return writeFile(".github/hooks/toasty.json", hookJson);
+}
+
+bool uninstallCopilot() {
+    if (fs::exists(".github/hooks/toasty.json")) {
+        return fs::remove(".github/hooks/toasty.json");
+    }
+    return true;
+}
+
+// Check if agents are available
+bool isClaudeAvailable() {
+    return fs::exists(getHomeDir() + "/.claude");
+}
+
+bool isGeminiAvailable() {
+    return fs::exists(getHomeDir() + "/.gemini");
+}
+
+bool isCopilotAvailable() {
+    return fs::exists(".git");
+}
+
+// Status command
+void showStatus() {
+    std::cout << "Toasty Hook Status\n";
+    std::cout << "==================\n\n";
+    
+    std::cout << "Claude Code:    ";
+    if (isClaudeInstalled()) {
+        std::cout << "[x] Installed\n";
+    } else if (isClaudeAvailable()) {
+        std::cout << "[ ] Available (not installed)\n";
+    } else {
+        std::cout << "[-] Not detected\n";
+    }
+    
+    std::cout << "Gemini CLI:     ";
+    if (isGeminiInstalled()) {
+        std::cout << "[x] Installed\n";
+    } else if (isGeminiAvailable()) {
+        std::cout << "[ ] Available (not installed)\n";
+    } else {
+        std::cout << "[-] Not detected\n";
+    }
+    
+    std::cout << "GitHub Copilot: ";
+    if (isCopilotInstalled()) {
+        std::cout << "[x] Installed (this repo)\n";
+    } else if (isCopilotAvailable()) {
+        std::cout << "[ ] Available (not installed)\n";
+    } else {
+        std::cout << "[-] Not a git repository\n";
+    }
+}
+
+// Install command
+void runInstall(const std::string& agent) {
+    std::cout << "Detecting AI CLI agents...\n";
+    
+    bool claudeAvail = isClaudeAvailable();
+    bool geminiAvail = isGeminiAvailable();
+    bool copilotAvail = isCopilotAvailable();
+    
+    std::cout << "  " << (claudeAvail ? "[x]" : "[ ]") << " Claude Code" << (isClaudeInstalled() ? " (already installed)" : "") << "\n";
+    std::cout << "  " << (geminiAvail ? "[x]" : "[ ]") << " Gemini CLI" << (isGeminiInstalled() ? " (already installed)" : "") << "\n";
+    std::cout << "  " << (copilotAvail ? "[x]" : "[ ]") << " GitHub Copilot (in current repo)" << (isCopilotInstalled() ? " (already installed)" : "") << "\n";
+    
+    std::cout << "\nInstalling toasty hooks...\n";
+    
+    bool anyInstalled = false;
+    auto lowerAgent = toLower(agent);
+    
+    if ((lowerAgent.empty() || lowerAgent == "all" || lowerAgent == "claude") && claudeAvail && !isClaudeInstalled()) {
+        if (installClaude()) {
+            std::cout << "  [x] Claude Code: Added Stop hook\n";
+            anyInstalled = true;
+        } else {
+            std::cout << "  [ ] Claude Code: Failed to install\n";
+        }
+    }
+    
+    if ((lowerAgent.empty() || lowerAgent == "all" || lowerAgent == "gemini") && geminiAvail && !isGeminiInstalled()) {
+        if (installGemini()) {
+            std::cout << "  [x] Gemini CLI: Added AfterAgent hook\n";
+            anyInstalled = true;
+        } else {
+            std::cout << "  [ ] Gemini CLI: Failed to install\n";
+        }
+    }
+    
+    if ((lowerAgent.empty() || lowerAgent == "all" || lowerAgent == "copilot") && copilotAvail && !isCopilotInstalled()) {
+        if (installCopilot()) {
+            std::cout << "  [x] GitHub Copilot: Added sessionEnd hook\n";
+            anyInstalled = true;
+        } else {
+            std::cout << "  [ ] GitHub Copilot: Failed to install\n";
+        }
+    }
+    
+    if (anyInstalled) {
+        std::cout << "\nDone! You'll get notifications when AI agents finish.\n";
+    } else {
+        std::cout << "\nNo new hooks installed.\n";
+    }
+}
+
+// Uninstall command
+void runUninstall() {
+    std::cout << "Removing toasty hooks...\n";
+    
+    bool anyRemoved = false;
+    
+    if (isClaudeInstalled()) {
+        if (uninstallClaude()) {
+            std::cout << "  [x] Claude Code: Removed hooks\n";
+            anyRemoved = true;
+        }
+    }
+    
+    if (isGeminiInstalled()) {
+        if (uninstallGemini()) {
+            std::cout << "  [x] Gemini CLI: Removed hooks\n";
+            anyRemoved = true;
+        }
+    }
+    
+    if (isCopilotInstalled()) {
+        if (uninstallCopilot()) {
+            std::cout << "  [x] GitHub Copilot: Removed hooks\n";
+            anyRemoved = true;
+        }
+    }
+    
+    if (anyRemoved) {
+        std::cout << "\nDone! Hooks have been removed.\n";
+    } else {
+        std::cout << "\nNo hooks were installed.\n";
+    }
+}
+
+// Print usage
+void printUsage() {
+    std::cout << "toasty - macOS toast notification CLI\n\n"
+              << "Usage:\n"
+              << "  toasty <message> [options]\n"
+              << "  toasty --install [agent]\n"
+              << "  toasty --uninstall\n"
+              << "  toasty --status\n\n"
+              << "Options:\n"
+              << "  -t, --title <text>   Set notification title (default: \"Notification\")\n"
+              << "  --app <name>         Use AI CLI preset (claude, copilot, gemini, codex, cursor)\n"
+              << "  -i, --icon <path>    Custom icon path (PNG recommended)\n"
+              << "  -h, --help           Show this help\n"
+              << "  --install [agent]    Install hooks for AI CLI agents (claude, gemini, copilot, or all)\n"
+              << "  --uninstall          Remove hooks from all AI CLI agents\n"
+              << "  --status             Show installation status\n"
+              << "  --debug              Show process detection debug info\n\n"
+              << "Note: Toasty auto-detects known parent processes (Claude, Copilot, etc.)\n"
+              << "      and applies the appropriate preset automatically. Use --app to override.\n\n"
+              << "Examples:\n"
+              << "  toasty \"Build completed\"\n"
+              << "  toasty \"Task done\" -t \"Custom Title\"\n"
+              << "  toasty \"Analysis complete\" --app claude\n"
+              << "  toasty --install\n"
+              << "  toasty --status\n";
+}
+
+int main(int argc, char* argv[]) {
+    @autoreleasepool {
+        std::vector<std::string> args;
+        for (int i = 1; i < argc; i++) {
+            args.push_back(argv[i]);
+        }
+        
+        if (args.empty()) {
+            printUsage();
+            return 0;
+        }
+        
+        // Parse arguments
+        std::string message;
+        std::string title = "Notification";
+        std::string iconPath;
+        std::string appPreset;
+        bool debug = false;
+        bool doInstall = false;
+        bool doUninstall = false;
+        bool doStatus = false;
+        std::string installAgent;
+        
+        for (size_t i = 0; i < args.size(); i++) {
+            const auto& arg = args[i];
+            
+            if (arg == "-h" || arg == "--help") {
+                printUsage();
+                return 0;
+            } else if (arg == "--status") {
+                doStatus = true;
+            } else if (arg == "--install") {
+                doInstall = true;
+                if (i + 1 < args.size() && args[i + 1][0] != '-') {
+                    installAgent = args[++i];
+                }
+            } else if (arg == "--uninstall") {
+                doUninstall = true;
+            } else if (arg == "--debug") {
+                debug = true;
+            } else if ((arg == "-t" || arg == "--title") && i + 1 < args.size()) {
+                title = args[++i];
+            } else if (arg == "--app" && i + 1 < args.size()) {
+                appPreset = args[++i];
+            } else if ((arg == "-i" || arg == "--icon") && i + 1 < args.size()) {
+                iconPath = args[++i];
+            } else if (arg[0] != '-') {
+                message = arg;
+            }
+        }
+        
+        // Handle commands
+        if (doStatus) {
+            showStatus();
+            return 0;
+        }
+        
+        if (doInstall) {
+            runInstall(installAgent);
+            return 0;
+        }
+        
+        if (doUninstall) {
+            runUninstall();
+            return 0;
+        }
+        
+        // Need a message for notification
+        if (message.empty()) {
+            std::cerr << "Error: No message provided.\n";
+            printUsage();
+            return 1;
+        }
+        
+        // Auto-detect preset from parent process
+        const AppPreset* preset = nullptr;
+        if (!appPreset.empty()) {
+            preset = findPreset(appPreset);
+            if (!preset) {
+                std::cerr << "Warning: Unknown app preset '" << appPreset << "'\n";
+            }
+        } else {
+            preset = detectPresetFromAncestors(debug);
+        }
+        
+        // Apply preset
+        if (preset) {
+            if (title == "Notification") {
+                title = preset->title;
+            }
+            if (iconPath.empty()) {
+                iconPath = getIconPath(preset);
+            }
+        }
+        
+        // Show notification
+        if (!showNotification(title, message, iconPath)) {
+            std::cerr << "Error: Failed to show notification.\n";
+            return 1;
+        }
+        
+        return 0;
+    }
+}

--- a/tests/test_mac.sh
+++ b/tests/test_mac.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Test script for toasty macOS build
+# Run from repository root: ./tests/test_mac.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOASTY="${REPO_ROOT}/build/toasty"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+PASSED=0
+FAILED=0
+
+# Test helper functions
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    FAILED=$((FAILED + 1))
+}
+
+skip() {
+    echo -e "${YELLOW}○ SKIP${NC}: $1"
+}
+
+# Check if binary exists
+check_binary() {
+    if [[ ! -x "$TOASTY" ]]; then
+        echo -e "${RED}Error: toasty binary not found at $TOASTY${NC}"
+        echo "Build first with: cmake -S . -B build && cmake --build build"
+        exit 1
+    fi
+    pass "Binary exists and is executable"
+}
+
+# Test: Help flag shows usage
+test_help() {
+    local output
+    output=$("$TOASTY" --help 2>&1)
+    
+    if echo "$output" | grep -q "Usage:"; then
+        pass "--help shows usage"
+    else
+        fail "--help should show usage"
+    fi
+    
+    if echo "$output" | grep -q "toasty <message>"; then
+        pass "--help shows message syntax"
+    else
+        fail "--help should show message syntax"
+    fi
+    
+    if echo "$output" | grep -q "\-t, --title"; then
+        pass "--help shows title option"
+    else
+        fail "--help should show title option"
+    fi
+    
+    if echo "$output" | grep -q "\--install"; then
+        pass "--help shows install option"
+    else
+        fail "--help should show install option"
+    fi
+}
+
+# Test: No args shows help
+test_no_args() {
+    local output
+    output=$("$TOASTY" 2>&1)
+    
+    if echo "$output" | grep -q "Usage:"; then
+        pass "No args shows usage"
+    else
+        fail "No args should show usage"
+    fi
+}
+
+# Test: Status command runs
+test_status() {
+    local output
+    local exit_code
+    
+    output=$("$TOASTY" --status 2>&1) && exit_code=0 || exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "--status exits with code 0"
+    else
+        fail "--status should exit with code 0"
+    fi
+    
+    if echo "$output" | grep -q "Claude Code"; then
+        pass "--status shows Claude Code"
+    else
+        fail "--status should show Claude Code"
+    fi
+    
+    if echo "$output" | grep -q "Gemini CLI"; then
+        pass "--status shows Gemini CLI"
+    else
+        fail "--status should show Gemini CLI"
+    fi
+    
+    if echo "$output" | grep -q "GitHub Copilot"; then
+        pass "--status shows GitHub Copilot"
+    else
+        fail "--status should show GitHub Copilot"
+    fi
+}
+
+# Test: Debug flag works
+test_debug() {
+    local output
+    output=$("$TOASTY" "test" --debug 2>&1)
+    
+    if echo "$output" | grep -q "\[DEBUG\]"; then
+        pass "--debug shows debug output"
+    else
+        fail "--debug should show debug output"
+    fi
+}
+
+# Test: Notification with message (visual test - just check it doesn't crash)
+test_notification() {
+    local exit_code
+    
+    "$TOASTY" "Test notification from toasty" -t "Toasty Test" >/dev/null 2>&1 && exit_code=0 || exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "Notification command exits cleanly"
+        echo "  (Check your notification center for the test notification)"
+    else
+        fail "Notification command should exit with code 0"
+    fi
+}
+
+# Test: App preset flag
+test_app_preset() {
+    local exit_code
+    
+    # Test with valid preset
+    "$TOASTY" "Testing Claude preset" --app claude >/dev/null 2>&1 && exit_code=0 || exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "--app claude works"
+    else
+        fail "--app claude should work"
+    fi
+    
+    # Test with invalid preset (should warn but still work)
+    "$TOASTY" "Testing invalid preset" --app invalid 2>&1 | grep -q "Warning" && exit_code=0 || exit_code=1
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "--app with invalid preset shows warning"
+    else
+        fail "--app with invalid preset should show warning"
+    fi
+}
+
+# Test: Title option
+test_title_option() {
+    local exit_code
+    
+    "$TOASTY" "Message with custom title" -t "Custom Title" >/dev/null 2>&1 && exit_code=0 || exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "-t option works"
+    else
+        fail "-t option should work"
+    fi
+    
+    "$TOASTY" "Message with long title" --title "Long Form Title" >/dev/null 2>&1 && exit_code=0 || exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+        pass "--title option works"
+    else
+        fail "--title option should work"
+    fi
+}
+
+# Run all tests
+main() {
+    echo "========================================"
+    echo "Toasty macOS Test Suite"
+    echo "========================================"
+    echo ""
+    
+    check_binary
+    echo ""
+    
+    echo "--- Help & Usage Tests ---"
+    test_help
+    test_no_args
+    echo ""
+    
+    echo "--- Status Command Tests ---"
+    test_status
+    echo ""
+    
+    echo "--- Debug Flag Tests ---"
+    test_debug
+    echo ""
+    
+    echo "--- Notification Tests ---"
+    test_notification
+    test_app_preset
+    test_title_option
+    echo ""
+    
+    echo "========================================"
+    printf "Results: ${GREEN}%d passed${NC}, ${RED}%d failed${NC}\n" "$PASSED" "$FAILED"
+    echo "========================================"
+    
+    if [[ $FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds native macOS support to Toasty, allowing Mac developers to receive notifications when AI coding agents complete their tasks.

Fixes #27

## Changes

- **`main_mac.mm`** - Native Objective-C++ implementation for macOS
- **`CMakeLists.txt`** - Cross-platform build support (Windows/macOS)
- **`tests/test_mac.sh`** - macOS test suite (16 tests, all passing)
- **`README.md`** - Updated with macOS installation and setup instructions

## Features

- ✅ Notifications via `terminal-notifier` (reliable on macOS 15+)
- ✅ AI agent auto-detection (Claude, Copilot, Gemini, Codex, Cursor)
- ✅ Icons for all presets
- ✅ Hook installation for Claude, Gemini, and Copilot
- ✅ Same CLI interface as Windows version

## Requirements (macOS)

- macOS 10.15+
- `terminal-notifier` (`brew install terminal-notifier`)
- Notification permissions enabled in System Settings

## Screenshots

*Notifications with icons for GitHub Copilot and Claude:*

<img width="354" height="335" alt="Screenshot 2026-01-23 at 11 00 22" src="https://github.com/user-attachments/assets/d967ad63-31aa-4d71-a36f-43ebaab63968" />


## Testing

```bash
# Build
clang++ -std=c++20 -x objective-c++ -framework Foundation -framework AppKit -o build/toasty main_mac.mm

# Run tests
./tests/test_mac.sh
```

All 16 tests passing on macOS 15 Sequoia.