### PR TITLE
feat(copilot): rich hooks, per-turn idle watchdog, click-to-focus, se…

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -153,7 +153,7 @@ Location: `~/.gemini/settings.json`
 
 ## GitHub Copilot CLI Hooks
 
-Location: `.github/hooks/*.json` (per-repo)
+Location: `.github/hooks/*.json` (per-repo) or `~/.copilot/hooks/*.json` (user-global, loaded for every repo). On Windows the global path is `%USERPROFILE%\.copilot\hooks\toasty.json`.
 
 | Event | Description | Notification Ideas |
 |-------|-------------|-------------------|
@@ -173,8 +173,16 @@ Location: `.github/hooks/*.json` (per-repo)
     "sessionEnd": [
       {
         "type": "command",
-        "bash": "toasty 'Copilot finished'",
-        "powershell": "toasty.exe 'Copilot finished'",
+        "bash": "toasty --copilot-hook end",
+        "powershell": "toasty.exe --copilot-hook end",
+        "timeoutSec": 5
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "toasty --copilot-hook prompt",
+        "powershell": "toasty.exe --copilot-hook prompt",
         "timeoutSec": 5
       }
     ],
@@ -189,6 +197,55 @@ Location: `.github/hooks/*.json` (per-repo)
   }
 }
 ```
+
+### Rich notifications via `--copilot-hook`
+
+`toasty --install copilot` installs three hooks (`sessionEnd`,
+`userPromptSubmitted`, and `postToolUse`) that invoke toasty in a special mode
+where it reads the JSON Copilot pipes to stdin and builds a richer toast:
+
+- The user prompt is captured on `userPromptSubmitted` and cached per-cwd
+  under `%LOCALAPPDATA%\toasty\copilot-prompts\`.
+- `sessionEnd` reads `reason` + `cwd` from stdin, looks up the cached prompt,
+  and shows e.g. `GitHub Copilot — "Refactor the auth module" - myrepo`. The
+  title varies by `reason` (`complete`, `timeout`, `error`, `abort`,
+  `user_exit`).
+- `postToolUse` arms a debounced **idle watchdog**: every tool call refreshes
+  a timer; when no new tool fires for `TOASTY_COPILOT_IDLE_SEC` seconds
+  (default 6), a detached watchdog process emits a `GitHub Copilot - ready`
+  toast. This is the workaround for Copilot CLI not emitting any per-turn
+  completion hook (see [issue #1128](https://github.com/github/copilot-cli/issues/1128)).
+  Submitting a new prompt or ending the session cancels the pending toast.
+- The cache file is deleted after read, and stale entries (>24h) are swept on
+  the next write.
+- If stdin is empty (e.g. you ran the command manually) toasty falls back to a
+  generic message instead of hanging.
+- **Session name in the title.** When the hook payload includes a `sessionId`
+  (newer Copilot CLI builds), toasty reads
+  `%USERPROFILE%\.copilot\session-state\<id>\workspace.yaml` and uses the
+  `name` field (falling back to `summary`, then `repository`) so toasts read
+  e.g. `GitHub Copilot - my-cool-session` or
+  `GitHub Copilot - my-cool-session (failed)`. If no `sessionId` is provided
+  the title stays as `GitHub Copilot`.
+
+### Per-repo vs. global install
+
+Copilot CLI loads hooks from two places:
+
+- `.github/hooks/*.json` — per-repo, only active in that repository.
+- `~/.copilot/hooks/*.json` — user-global, active in every directory you run
+  Copilot CLI from. On Windows this is `%USERPROFILE%\.copilot\hooks\toasty.json`.
+
+`toasty --install copilot` writes the per-repo file. Add `--global` to write
+the user-global file instead:
+
+```powershell
+toasty --install copilot --global
+```
+
+Both are independent — you can install one or both. `toasty --uninstall`
+removes hooks from both locations and `toasty --status` reports each one
+separately.
 
 ### Hook Payloads
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options:
   -v, --version        Show version and exit
   -h, --help           Show this help
   --install [agent]    Install hooks for AI CLI agents (claude, gemini, copilot, or all)
+  --global             With --install copilot: install user-global hook (~/.copilot/hooks/) instead of per-repo
   --uninstall          Remove hooks from all AI CLI agents
   --status             Show installation status
   --dry-run            Show what would happen without executing side effects
@@ -36,7 +37,7 @@ Options:
 | Agent | Icon | Auto-Detect | `--install` | Hook Type | Config Location |
 |-------|:----:|:-----------:|:-----------:|-----------|-----------------|
 | Claude Code | ✅ | ✅ | ✅ | `Stop` | `~/.claude/settings.json` |
-| GitHub Copilot | ✅ | ✅ | ✅ | `sessionEnd` | `.github/hooks/toasty.json` |
+| GitHub Copilot | ✅ | ✅ | ✅ | `sessionEnd` | `.github/hooks/toasty.json` (repo) or `~/.copilot/hooks/toasty.json` (global, via `--global`) |
 | Gemini CLI | ✅ | ✅ | ✅ | `AfterAgent` | `~/.gemini/settings.json` |
 | OpenAI Codex | ✅ | ✅ | ✅ | `notify` | `~/.codex/config.toml` |
 
@@ -84,6 +85,7 @@ toasty --install
 toasty --install claude
 toasty --install gemini
 toasty --install copilot
+toasty --install copilot --global   # install once for all repos (~/.copilot/hooks/)
 
 # Check what's installed
 toasty --status
@@ -157,7 +159,8 @@ Add to `~/.gemini/settings.json`:
 
 ### GitHub Copilot
 
-Add to `.github/hooks/toasty.json`:
+Add to `.github/hooks/toasty.json` (per-repo) **or** `~/.copilot/hooks/toasty.json`
+(user-global, applies in every directory you run Copilot CLI from):
 
 ```json
 {
@@ -166,14 +169,85 @@ Add to `.github/hooks/toasty.json`:
     "sessionEnd": [
       {
         "type": "command",
-        "bash": "toasty 'Copilot finished'",
-        "powershell": "toasty.exe 'Copilot finished'",
+        "bash": "toasty --copilot-hook end",
+        "powershell": "toasty.exe --copilot-hook end",
+        "timeoutSec": 5
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "toasty --copilot-hook prompt",
+        "powershell": "toasty.exe --copilot-hook prompt",
         "timeoutSec": 5
       }
     ]
   }
 }
 ```
+
+When installed via `toasty --install copilot`, three hooks are configured:
+`sessionEnd`, `userPromptSubmitted`, **and `postToolUse`** at the repo level
+(`.github/hooks/toasty.json`). Pass `--global` to install once for your entire
+user account (`~/.copilot/hooks/toasty.json`, which on Windows is
+`%USERPROFILE%\.copilot\hooks\toasty.json`) so you get notifications regardless
+of which directory you launch Copilot CLI from. `toasty --uninstall` removes
+both locations.
+
+Pass `--no-session-end` if you don't want a toast when sessions end (`/exit`
+or Ctrl+C) — only the per-turn idle watchdog and the silent prompt-cache
+hooks will be installed. Re-running with the flag also strips a previously
+installed `sessionEnd` entry; re-running without it restores it.
+
+### Per-turn idle notifications (workaround)
+
+Copilot CLI does **not** emit a hook when a single turn completes within an
+interactive session — `sessionEnd` only fires on `/exit` or Ctrl+C. As a
+workaround, toasty installs a `postToolUse` hook that arms a debounced **idle
+watchdog**: every tool call refreshes a "fire toast in N seconds" timer. If
+Copilot stops calling tools for N seconds, you get a toast like:
+
+> *GitHub Copilot - my-cool-session (ready) - "Refactor the auth module" - myrepo*
+
+Tunable via `TOASTY_COPILOT_IDLE_SEC` (default 6 seconds, range 1-3600).
+The watchdog auto-cancels when you submit your next prompt or exit the
+session. Caveat: turns where Copilot replies without using any tool won't
+trigger it. Track upstream issue
+[`github/copilot-cli#1128`](https://github.com/github/copilot-cli/issues/1128)
+for a proper `awaitingUserInput` hook.
+
+When the hook payload includes a `sessionId` (newer Copilot CLI builds),
+toasty reads `~/.copilot/session-state/<id>/workspace.yaml` and weaves the
+session `name` (or `summary`) into the toast title — handy for
+distinguishing notifications from multiple concurrent Copilot sessions.
+
+**Click to focus the terminal.** Toasts emitted by toasty embed the
+terminal window's HWND in the activation URL
+(`toasty://focus?hwnd=<n>`). Clicking the toast brings that exact window
+to the foreground — so even with several Copilot sessions running across
+different windows, each notification routes you back to the right one.
+For the per-turn idle watchdog, the HWND is captured at hook time (while
+Copilot is still your direct child) and stashed in the pending record so
+the detached watchdog can pass it to the toast.
+
+> Caveat for Windows Terminal users with multiple tabs in one window:
+> only the *window* can be focused, not the specific tab inside it. WT
+> doesn't expose a public API for cross-process tab targeting. If you
+> switch tabs after starting a Copilot session, the click will land on
+> whatever tab is currently active in that window.
+
+The `--copilot-hook` modes read the JSON payload Copilot pipes to
+stdin (`cwd`, `reason`, `prompt`, `sessionId`), so the toast that fires at
+session end shows your task and folder, e.g.:
+
+- *GitHub Copilot - my-cool-session — "Refactor the auth module" - myrepo*
+- *GitHub Copilot - my-cool-session (timed out)*
+- *GitHub Copilot - failed* (when no `sessionId` present)
+
+The `userPromptSubmitted` hook silently caches the latest prompt per-cwd
+under `%LOCALAPPDATA%\toasty\copilot-prompts\` so `sessionEnd` can show it.
+Cached prompts are deleted on read and any leftovers older than 24 hours are
+swept on the next prompt.
 
 ## Push Notifications (ntfy)
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,8 +14,12 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
 #include <tlhelp32.h>
 #include <winhttp.h>
+#include <knownfolders.h>
 #include "resource.h"
 
 #pragma comment(lib, "shlwapi.lib")
@@ -299,6 +303,8 @@ void print_usage() {
                << L"  -v, --version        Show version and exit\n"
                << L"  -h, --help           Show this help\n"
                << L"  --install [agent]    Install hooks for AI CLI agents (claude, gemini, copilot, codex, or all)\n"
+               << L"  --global             With --install copilot: install user-global hook (~/.copilot/hooks/) instead of per-repo\n"
+               << L"  --no-session-end     With --install copilot: skip the sessionEnd hook (no toast on /exit or Ctrl+C)\n"
                << L"  --uninstall          Remove hooks from all AI CLI agents\n"
                << L"  --status             Show installation status\n"
                << L"  --register           Re-register app for notifications (troubleshooting)\n"
@@ -1089,16 +1095,41 @@ bool install_gemini(const std::wstring& exePath) {
 }
 
 // Install hook for GitHub Copilot
-bool install_copilot(const std::wstring& exePath) {
-    std::wstring hooksDir = L".github\\hooks";
-    std::wstring configPath = hooksDir + L"\\toasty.json";
-    
-    // Create .github/hooks directory if it doesn't exist
-    fs::create_directories(hooksDir);
-    
+// Returns the path to the per-repo Copilot hook config (relative to cwd).
+std::wstring copilot_repo_config_path() {
+    return L".github\\hooks\\toasty.json";
+}
+
+// Returns the path to the user-global Copilot hook config, or empty on
+// failure to resolve the home directory.
+std::wstring copilot_global_config_path() {
+    // Prefer %USERPROFILE% so test harnesses (and users) can override the
+    // target via the standard Windows env var. Fall back to the canonical
+    // shell path if it's unset.
+    std::wstring home = expand_env(L"%USERPROFILE%");
+    if (home.empty()) {
+        PWSTR p = nullptr;
+        if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &p))) {
+            home = p;
+            CoTaskMemFree(p);
+        }
+    }
+    if (home.empty()) return L"";
+    return home + L"\\.copilot\\hooks\\toasty.json";
+}
+
+bool install_copilot_at(const std::wstring& exePath, const std::wstring& configPath,
+                        bool noSessionEnd) {
+    if (configPath.empty()) return false;
+
+    fs::path cfg(configPath);
+    std::error_code ec;
+    fs::create_directories(cfg.parent_path(), ec);
+    if (ec) return false;
+
     JsonObject rootObj;
     std::string existingContent = read_file(configPath);
-    
+
     if (!existingContent.empty()) {
         try {
             backup_file(configPath);
@@ -1108,55 +1139,842 @@ bool install_copilot(const std::wstring& exePath) {
             rootObj = JsonObject();
         }
     }
-    
-    // Set version
+
     rootObj.SetNamedValue(L"version", JsonValue::CreateNumberValue(1));
-    
-    // Build hook structure
-    JsonObject hookObj;
-    hookObj.SetNamedValue(L"type", JsonValue::CreateStringValue(L"command"));
-    
-    // For bash, use forward slashes and toasty (assuming it's in PATH)
-    hookObj.SetNamedValue(L"bash", JsonValue::CreateStringValue(L"toasty 'Copilot finished' -t 'GitHub Copilot'"));
-    
-    // For PowerShell, use the full exe path with escaped backslashes
-    std::wstring escapedPath = escape_json_string(exePath);
-    std::wstring psCommand = escapedPath + L" 'Copilot finished' -t 'GitHub Copilot'";
-    hookObj.SetNamedValue(L"powershell", JsonValue::CreateStringValue(psCommand));
-    
-    hookObj.SetNamedValue(L"timeoutSec", JsonValue::CreateNumberValue(5));
-    
-    // Get or create hooks object
+
     JsonObject hooksObj;
     if (rootObj.HasKey(L"hooks")) {
         hooksObj = rootObj.GetNamedObject(L"hooks");
     }
-    
-    // Get or create sessionEnd array
-    JsonArray sessionEndArray;
-    if (hooksObj.HasKey(L"sessionEnd")) {
-        sessionEndArray = hooksObj.GetNamedArray(L"sessionEnd");
-        // Check if toasty is already there
-        for (const auto& item : sessionEndArray) {
-            if (item.ValueType() == JsonValueType::Object) {
-                auto obj = item.GetObject();
-                if (obj.HasKey(L"bash")) {
-                    std::wstring bash = obj.GetNamedString(L"bash").c_str();
-                    if (bash.find(L"toasty") != std::wstring::npos) {
-                        return true; // Already installed
-                    }
-                }
+
+    auto buildHook = [&](const std::wstring& event) {
+        JsonObject h;
+        h.SetNamedValue(L"type", JsonValue::CreateStringValue(L"command"));
+        std::wstring bash = L"toasty --copilot-hook " + event;
+        std::wstring ps = exePath + L" --copilot-hook " + event;
+        h.SetNamedValue(L"bash", JsonValue::CreateStringValue(bash.c_str()));
+        h.SetNamedValue(L"powershell", JsonValue::CreateStringValue(ps.c_str()));
+        h.SetNamedValue(L"timeoutSec", JsonValue::CreateNumberValue(5));
+        return h;
+    };
+
+    auto isToastyEntry = [](const JsonObject& o) {
+        auto check = [&](const wchar_t* key) {
+            if (!o.HasKey(key)) return false;
+            try {
+                std::wstring v = o.GetNamedString(key).c_str();
+                return v.find(L"toasty") != std::wstring::npos;
+            } catch (...) { return false; }
+        };
+        return check(L"bash") || check(L"powershell") || check(L"command");
+    };
+
+    auto upsertHook = [&](const wchar_t* eventName, JsonObject newEntry) {
+        JsonArray arr;
+        if (hooksObj.HasKey(eventName)) {
+            try { arr = hooksObj.GetNamedArray(eventName); }
+            catch (...) { arr = JsonArray(); }
+        }
+        JsonArray cleaned;
+        for (const auto& item : arr) {
+            if (item.ValueType() != JsonValueType::Object) {
+                cleaned.Append(item);
+                continue;
+            }
+            auto o = item.GetObject();
+            if (!isToastyEntry(o)) cleaned.Append(item);
+        }
+        cleaned.Append(newEntry);
+        hooksObj.SetNamedValue(eventName, cleaned);
+    };
+
+    // Remove any toasty entry for an event without re-adding one. If the
+    // resulting array is empty, drop the event key entirely so the config
+    // stays clean.
+    auto removeToastyHook = [&](const wchar_t* eventName) {
+        if (!hooksObj.HasKey(eventName)) return;
+        JsonArray arr;
+        try { arr = hooksObj.GetNamedArray(eventName); }
+        catch (...) { return; }
+        JsonArray cleaned;
+        for (const auto& item : arr) {
+            if (item.ValueType() != JsonValueType::Object) {
+                cleaned.Append(item);
+                continue;
+            }
+            auto o = item.GetObject();
+            if (!isToastyEntry(o)) cleaned.Append(item);
+        }
+        if (cleaned.Size() == 0) hooksObj.Remove(eventName);
+        else hooksObj.SetNamedValue(eventName, cleaned);
+    };
+
+    if (noSessionEnd) {
+        removeToastyHook(L"sessionEnd");
+    } else {
+        upsertHook(L"sessionEnd", buildHook(L"end"));
+    }
+    upsertHook(L"userPromptSubmitted", buildHook(L"prompt"));
+    upsertHook(L"postToolUse", buildHook(L"tool"));
+
+    rootObj.SetNamedValue(L"hooks", hooksObj);
+
+    std::string jsonStr = from_hstring(rootObj.Stringify());
+    return write_file(configPath, jsonStr);
+}
+
+bool install_copilot(const std::wstring& exePath, bool noSessionEnd = false) {
+    return install_copilot_at(exePath, copilot_repo_config_path(), noSessionEnd);
+}
+
+bool install_copilot_global(const std::wstring& exePath, bool noSessionEnd = false) {
+    return install_copilot_at(exePath, copilot_global_config_path(), noSessionEnd);
+}
+
+// =============================================================
+// Copilot rich notification helpers
+// =============================================================
+
+// Read all of stdin as UTF-8. Returns empty string if stdin is the console
+// (avoids hanging when invoked manually) or on read failure.
+std::string read_stdin_utf8() {
+    HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
+    if (h == INVALID_HANDLE_VALUE || h == nullptr) return "";
+    DWORD type = GetFileType(h);
+    // Only read from a pipe or redirected file. FILE_TYPE_CHAR == interactive
+    // console: do not read (would block forever).
+    if (type != FILE_TYPE_PIPE && type != FILE_TYPE_DISK) return "";
+
+    std::string out;
+    char buf[4096];
+    DWORD bytesRead = 0;
+    while (ReadFile(h, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead > 0) {
+        out.append(buf, buf + bytesRead);
+    }
+    return out;
+}
+
+// FNV-1a 64-bit hash of a wstring (case-folded ASCII), as 16-hex-char string.
+std::wstring fnv1a_hex(const std::wstring& s) {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (wchar_t c : s) {
+        wchar_t lc = (c >= L'A' && c <= L'Z') ? (wchar_t)(c + 32) : c;
+        h ^= (uint64_t)lc;
+        h *= 0x100000001b3ULL;
+    }
+    wchar_t buf[17];
+    swprintf(buf, 17, L"%016llx", (unsigned long long)h);
+    return std::wstring(buf);
+}
+
+// Get %LocalAppData% via SHGetKnownFolderPath. Empty on failure.
+std::wstring get_local_appdata() {
+    PWSTR path = nullptr;
+    if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &path))) {
+        std::wstring r(path);
+        CoTaskMemFree(path);
+        return r;
+    }
+    return L"";
+}
+
+std::wstring copilot_cache_dir() {
+    std::wstring base = get_local_appdata();
+    if (base.empty()) return L"";
+    return base + L"\\toasty\\copilot-prompts";
+}
+
+// =============================================================
+// Idle watchdog: postToolUse debounce -> toast on N seconds of inactivity
+// =============================================================
+
+// Forward declarations for helpers defined further down.
+std::wstring normalize_ws(const std::wstring& in);
+std::wstring truncate_w(const std::wstring& s, size_t maxChars);
+std::wstring folder_name_of(const std::wstring& cwd);
+
+std::wstring copilot_pending_dir() {
+    std::wstring base = get_local_appdata();
+    if (base.empty()) return L"";
+    return base + L"\\toasty\\copilot-pending";
+}
+
+std::wstring copilot_pending_path(const std::wstring& cwd) {
+    std::wstring dir = copilot_pending_dir();
+    if (dir.empty()) return L"";
+    return dir + L"\\" + fnv1a_hex(cwd) + L".json";
+}
+
+std::wstring copilot_pending_path_by_hash(const std::wstring& hash) {
+    std::wstring dir = copilot_pending_dir();
+    if (dir.empty()) return L"";
+    return dir + L"\\" + hash + L".json";
+}
+
+std::wstring copilot_lock_path_by_hash(const std::wstring& hash) {
+    std::wstring dir = copilot_pending_dir();
+    if (dir.empty()) return L"";
+    return dir + L"\\" + hash + L".lock";
+}
+
+// Idle threshold in seconds. Reads TOASTY_COPILOT_IDLE_SEC env var; default 6.
+unsigned copilot_idle_seconds() {
+    wchar_t buf[32] = {};
+    if (GetEnvironmentVariableW(L"TOASTY_COPILOT_IDLE_SEC", buf, 32) > 0) {
+        wchar_t* end = nullptr;
+        unsigned long v = wcstoul(buf, &end, 10);
+        if (v >= 1 && v <= 3600) return (unsigned)v;
+    }
+    return 6;
+}
+
+uint64_t now_ms() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+// Atomically write a JSON pending record. Best-effort.
+bool write_pending(const std::wstring& cwd, uint64_t fireMs,
+                   const std::wstring& prompt, const std::wstring& sessionName,
+                   uint64_t hwnd) {
+    std::wstring path = copilot_pending_path(cwd);
+    if (path.empty()) return false;
+    std::error_code ec;
+    fs::create_directories(copilot_pending_dir(), ec);
+
+    JsonObject o;
+    o.SetNamedValue(L"fireMs", JsonValue::CreateNumberValue((double)fireMs));
+    o.SetNamedValue(L"cwd", JsonValue::CreateStringValue(cwd.c_str()));
+    o.SetNamedValue(L"prompt", JsonValue::CreateStringValue(prompt.c_str()));
+    o.SetNamedValue(L"sessionName", JsonValue::CreateStringValue(sessionName.c_str()));
+    o.SetNamedValue(L"hwnd", JsonValue::CreateNumberValue((double)hwnd));
+    std::string json = from_hstring(o.Stringify());
+
+    // Write to <path>.tmp then rename for atomicity.
+    std::wstring tmp = path + L".tmp";
+    if (!write_file(tmp, json)) return false;
+    fs::rename(tmp, path, ec);
+    if (ec) {
+        // Fallback: write directly (last-write-wins).
+        return write_file(path, json);
+    }
+    return true;
+}
+
+struct PendingRecord {
+    bool exists = false;
+    uint64_t fireMs = 0;
+    std::wstring cwd;
+    std::wstring prompt;
+    std::wstring sessionName;
+    uint64_t hwnd = 0;
+};
+
+PendingRecord read_pending_by_hash(const std::wstring& hash) {
+    PendingRecord r;
+    std::wstring path = copilot_pending_path_by_hash(hash);
+    if (path.empty() || !path_exists(path)) return r;
+    std::string raw = read_file(path);
+    if (raw.empty()) return r;
+    try {
+        JsonObject o = JsonObject::Parse(to_hstring(raw));
+        if (o.HasKey(L"fireMs")) r.fireMs = (uint64_t)o.GetNamedNumber(L"fireMs");
+        if (o.HasKey(L"cwd"))    r.cwd    = std::wstring(o.GetNamedString(L"cwd"));
+        if (o.HasKey(L"prompt")) r.prompt = std::wstring(o.GetNamedString(L"prompt"));
+        if (o.HasKey(L"sessionName"))
+            r.sessionName = std::wstring(o.GetNamedString(L"sessionName"));
+        if (o.HasKey(L"hwnd")) r.hwnd = (uint64_t)o.GetNamedNumber(L"hwnd");
+        r.exists = true;
+    } catch (...) {}
+    return r;
+}
+
+void cancel_pending(const std::wstring& cwd) {
+    std::wstring path = copilot_pending_path(cwd);
+    if (path.empty()) return;
+    std::error_code ec;
+    fs::remove(path, ec);
+}
+
+// Spawn a detached watchdog process for a given cwd hash. Best-effort.
+void spawn_watchdog(const std::wstring& cwdHash) {
+    std::wstring exe = get_exe_path();
+    if (exe.empty()) return;
+
+    std::wstring cmd = L"\"" + exe + L"\" --copilot-watchdog " + cwdHash;
+    std::vector<wchar_t> cmdBuf(cmd.begin(), cmd.end());
+    cmdBuf.push_back(L'\0');
+
+    STARTUPINFOW si = { sizeof(si) };
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+    PROCESS_INFORMATION pi = {};
+    DWORD flags = CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_BREAKAWAY_FROM_JOB;
+    if (CreateProcessW(nullptr, cmdBuf.data(), nullptr, nullptr, FALSE,
+                       flags, nullptr, nullptr, &si, &pi)) {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
+}
+
+// Run the watchdog loop for one cwd. Acquires a single-instance lock; if
+// another watchdog is already running for this cwd, exits immediately.
+// Polls the pending file; when fireMs <= now AND the file still exists,
+// spawns `toasty.exe --app copilot --title <t> "<msg>"` and exits.
+int run_copilot_watchdog(const std::wstring& hash) {
+    std::wstring lockPath = copilot_lock_path_by_hash(hash);
+    if (lockPath.empty()) return 0;
+
+    // Ensure parent dir exists for the lock too.
+    std::error_code ec;
+    fs::create_directories(copilot_pending_dir(), ec);
+
+    HANDLE lock = CreateFileW(lockPath.c_str(), GENERIC_WRITE, 0, nullptr,
+                              CREATE_NEW, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                              nullptr);
+    if (lock == INVALID_HANDLE_VALUE) {
+        // Another watchdog instance owns this cwd. That instance will pick up
+        // the refreshed fireMs on its next poll, so just exit.
+        return 0;
+    }
+
+    auto release = [&]() {
+        if (lock != INVALID_HANDLE_VALUE) {
+            CloseHandle(lock);  // FILE_FLAG_DELETE_ON_CLOSE removes the file.
+            lock = INVALID_HANDLE_VALUE;
+        }
+    };
+
+    const uint64_t maxLifetimeMs = 60ULL * 60ULL * 1000ULL;  // 1 hour cap
+    uint64_t startMs = now_ms();
+
+    PendingRecord toFire;
+    while (true) {
+        if (now_ms() - startMs > maxLifetimeMs) {
+            release();
+            return 0;
+        }
+        PendingRecord rec = read_pending_by_hash(hash);
+        if (!rec.exists) {
+            release();
+            return 0;
+        }
+        uint64_t now = now_ms();
+        if (rec.fireMs > now) {
+            uint64_t wait = rec.fireMs - now;
+            if (wait > 1000) wait = 1000;
+            Sleep((DWORD)wait);
+            continue;
+        }
+        toFire = rec;
+        // Atomically claim the toast: try to delete the file. If deletion
+        // fails (e.g. another process recreated it just now), re-loop.
+        std::wstring path = copilot_pending_path_by_hash(hash);
+        std::error_code dec;
+        if (!fs::remove(path, dec)) {
+            Sleep(50);
+            continue;
+        }
+        break;
+    }
+
+    // Build title and message just like sessionEnd does, but with an "idle"
+    // suffix so users can tell the difference. Then re-invoke toasty as the
+    // toast emitter (keeps WinRT/icon/ntfy logic in one place).
+    std::wstring folder = folder_name_of(toFire.cwd);
+    // Strip embedded double quotes from inputs to keep the re-exec command
+    // line robust (CreateProcessW parses its lpCommandLine; embedded quotes
+    // break our naive `"..."` quoting).
+    auto stripQuotes = [](std::wstring s) {
+        for (auto& c : s) if (c == L'"') c = L'\'';
+        return s;
+    };
+    std::wstring sessionName = stripQuotes(normalize_ws(toFire.sessionName));
+    std::wstring shortPrompt = truncate_w(stripQuotes(normalize_ws(toFire.prompt)), 80);
+    std::wstring title = L"GitHub Copilot - ready";
+    if (!sessionName.empty()) title = L"GitHub Copilot - " + sessionName + L" (ready)";
+    std::wstring message;
+    if (!shortPrompt.empty()) {
+        message = L"\"" + shortPrompt + L"\"";
+        if (!folder.empty()) message += L" - " + folder;
+    } else {
+        message = folder.empty() ? L"Awaiting input" : (L"Awaiting input - " + folder);
+    }
+    // Final safety cap on total body length.
+    message = truncate_w(message, 140);
+    title   = truncate_w(title, 100);
+
+    std::wstring exe = get_exe_path();
+    if (!exe.empty()) {
+        std::wstring cmd = L"\"" + exe + L"\" --app copilot --title \"" + title + L"\" \"" + message + L"\"";
+        if (toFire.hwnd != 0) {
+            cmd += L" --launch-hwnd " + std::to_wstring(toFire.hwnd);
+        }
+        std::vector<wchar_t> cmdBuf(cmd.begin(), cmd.end());
+        cmdBuf.push_back(L'\0');
+        STARTUPINFOW si = { sizeof(si) };
+        si.dwFlags = STARTF_USESHOWWINDOW;
+        si.wShowWindow = SW_HIDE;
+        PROCESS_INFORMATION pi = {};
+        DWORD flags = CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_BREAKAWAY_FROM_JOB;
+        CreateProcessW(nullptr, cmdBuf.data(), nullptr, nullptr, FALSE,
+                       flags, nullptr, nullptr, &si, &pi);
+        if (pi.hProcess) CloseHandle(pi.hProcess);
+        if (pi.hThread)  CloseHandle(pi.hThread);
+    }
+
+    release();
+    return 0;
+}
+
+// Convert UTF-8 to wstring (UTF-16). Returns empty on failure.
+std::wstring utf8_to_wide(const std::string& s) {
+    if (s.empty()) return L"";
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), nullptr, 0);
+    if (n <= 0) return L"";
+    std::wstring w((size_t)n, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), &w[0], n);
+    return w;
+}
+
+// Collapse CR/LF/tab to spaces, collapse runs of spaces, trim.
+std::wstring normalize_ws(const std::wstring& in) {
+    std::wstring tmp;
+    tmp.reserve(in.size());
+    for (wchar_t c : in) {
+        if (c == L'\r' || c == L'\n' || c == L'\t') tmp += L' ';
+        else tmp += c;
+    }
+    std::wstring out;
+    out.reserve(tmp.size());
+    bool prevSpace = false;
+    for (wchar_t c : tmp) {
+        if (c == L' ') {
+            if (!prevSpace) out += c;
+            prevSpace = true;
+        } else {
+            out += c;
+            prevSpace = false;
+        }
+    }
+    while (!out.empty() && out.back() == L' ') out.pop_back();
+    size_t start = 0;
+    while (start < out.size() && out[start] == L' ') ++start;
+    return out.substr(start);
+}
+
+// Truncate by wide-char count, append ellipsis if truncated.
+std::wstring truncate_w(const std::wstring& s, size_t maxChars) {
+    if (s.size() <= maxChars) return s;
+    return s.substr(0, maxChars) + L"...";
+}
+
+// Persist a Copilot prompt for later sessionEnd lookup. Best-effort.
+void cache_copilot_prompt(const std::wstring& cwd, uint64_t timestampMs,
+                          const std::wstring& prompt) {
+    if (cwd.empty() || prompt.empty()) return;
+    std::wstring dir = copilot_cache_dir();
+    if (dir.empty()) return;
+
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec) return;
+
+    std::wstring hash = fnv1a_hex(cwd);
+
+    // Sweep stale files (older than 24h) for any cwd. Best-effort, ignore errors.
+    auto cutoff = std::chrono::system_clock::now() - std::chrono::hours(24);
+    {
+        std::error_code iec;
+        for (auto it = fs::directory_iterator(dir, iec);
+             !iec && it != fs::directory_iterator(); it.increment(iec)) {
+            std::error_code fec;
+            if (!it->is_regular_file(fec)) continue;
+            auto ftime = fs::last_write_time(it->path(), fec);
+            if (fec) continue;
+            // Convert file_time_type to system_clock::time_point
+            auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+                ftime - decltype(ftime)::clock::now() + std::chrono::system_clock::now());
+            if (sctp < cutoff) {
+                std::error_code rec;
+                fs::remove(it->path(), rec);
             }
         }
     }
-    
-    sessionEndArray.Append(hookObj);
-    hooksObj.SetNamedValue(L"sessionEnd", sessionEndArray);
-    rootObj.SetNamedValue(L"hooks", hooksObj);
-    
-    // Write to file
-    std::string jsonStr = from_hstring(rootObj.Stringify());
-    return write_file(configPath, jsonStr);
+
+    wchar_t name[64];
+    swprintf(name, 64, L"%s-%020llu.txt", hash.c_str(),
+             (unsigned long long)timestampMs);
+    std::wstring filePath = dir + L"\\" + name;
+
+    std::wstring norm = truncate_w(normalize_ws(prompt), 512);
+
+    int n = WideCharToMultiByte(CP_UTF8, 0, norm.c_str(), (int)norm.size(),
+                                nullptr, 0, nullptr, nullptr);
+    if (n <= 0) return;
+    std::string utf8((size_t)n, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, norm.c_str(), (int)norm.size(),
+                        &utf8[0], n, nullptr, nullptr);
+    write_file(filePath, utf8);
+}
+
+// Look up the most recent cached prompt for a given cwd, with prompt
+// timestamp <= sessionEnd timestamp. Removes the matched file (and any
+// older same-cwd files) after read. Returns empty wstring if none found.
+std::wstring consume_copilot_prompt(const std::wstring& cwd, uint64_t endTs) {
+    if (cwd.empty()) return L"";
+    std::wstring dir = copilot_cache_dir();
+    if (dir.empty()) return L"";
+    std::wstring hash = fnv1a_hex(cwd);
+    std::wstring prefix = hash + L"-";
+
+    fs::path bestPath;
+    uint64_t bestTs = 0;
+    bool found = false;
+
+    std::error_code ec;
+    for (auto it = fs::directory_iterator(dir, ec);
+         !ec && it != fs::directory_iterator(); it.increment(ec)) {
+        std::error_code fec;
+        if (!it->is_regular_file(fec)) continue;
+        std::wstring name = it->path().filename().wstring();
+        if (name.size() < prefix.size() + 4) continue;
+        if (name.compare(0, prefix.size(), prefix) != 0) continue;
+        size_t end = name.rfind(L".txt");
+        if (end == std::wstring::npos || end <= prefix.size()) continue;
+        std::wstring tsStr = name.substr(prefix.size(), end - prefix.size());
+        uint64_t ts = 0;
+        try { ts = std::stoull(tsStr); }
+        catch (...) { continue; }
+        if (endTs > 0 && ts > endTs) continue;
+        if (!found || ts >= bestTs) {
+            bestTs = ts;
+            bestPath = it->path();
+            found = true;
+        }
+    }
+
+    std::wstring result;
+    if (found) {
+        std::string content = read_file(bestPath.wstring());
+        result = utf8_to_wide(content);
+        std::error_code rec;
+        for (auto it = fs::directory_iterator(dir, rec);
+             !rec && it != fs::directory_iterator(); it.increment(rec)) {
+            std::error_code fec;
+            if (!it->is_regular_file(fec)) continue;
+            std::wstring name = it->path().filename().wstring();
+            if (name.compare(0, prefix.size(), prefix) != 0) continue;
+            size_t end = name.rfind(L".txt");
+            if (end == std::wstring::npos || end <= prefix.size()) continue;
+            std::wstring tsStr = name.substr(prefix.size(), end - prefix.size());
+            uint64_t ts = 0;
+            try { ts = std::stoull(tsStr); } catch (...) { continue; }
+            if (ts <= bestTs) {
+                std::error_code re;
+                fs::remove(it->path(), re);
+            }
+        }
+    }
+    return result;
+}
+
+// Read-only variant of consume_copilot_prompt: returns the latest cached
+// prompt for cwd whose timestamp <= refTs (or any if refTs == 0). Does NOT
+// delete files. Used by the postToolUse path so it doesn't race with
+// sessionEnd consuming the same file.
+std::wstring peek_copilot_prompt(const std::wstring& cwd, uint64_t refTs) {
+    if (cwd.empty()) return L"";
+    std::wstring dir = copilot_cache_dir();
+    if (dir.empty()) return L"";
+    std::wstring hash = fnv1a_hex(cwd);
+    std::wstring prefix = hash + L"-";
+
+    fs::path bestPath;
+    uint64_t bestTs = 0;
+    bool found = false;
+
+    std::error_code ec;
+    for (auto it = fs::directory_iterator(dir, ec);
+         !ec && it != fs::directory_iterator(); it.increment(ec)) {
+        std::error_code fec;
+        if (!it->is_regular_file(fec)) continue;
+        std::wstring name = it->path().filename().wstring();
+        if (name.size() < prefix.size() + 4) continue;
+        if (name.compare(0, prefix.size(), prefix) != 0) continue;
+        size_t end = name.rfind(L".txt");
+        if (end == std::wstring::npos || end <= prefix.size()) continue;
+        std::wstring tsStr = name.substr(prefix.size(), end - prefix.size());
+        uint64_t ts = 0;
+        try { ts = std::stoull(tsStr); }
+        catch (...) { continue; }
+        if (refTs > 0 && ts > refTs) continue;
+        if (!found || ts >= bestTs) {
+            bestTs = ts;
+            bestPath = it->path();
+            found = true;
+        }
+    }
+    if (!found) return L"";
+    return utf8_to_wide(read_file(bestPath.wstring()));
+}
+
+// =============================================================
+// Copilot session-name lookup (via sessionId in hook payload)
+//
+// Newer Copilot CLI builds (verified against on-disk events.jsonl logs)
+// include a "sessionId" UUID in the hook input JSON. Each session writes
+// a workspace.yaml at %USERPROFILE%\.copilot\session-state\<id>\
+// containing fields like name, summary, repository, branch. We use those
+// to enrich the toast.
+// =============================================================
+
+std::wstring copilot_session_state_dir() {
+    std::wstring home = expand_env(L"%USERPROFILE%");
+    if (home.empty()) {
+        PWSTR p = nullptr;
+        if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &p))) {
+            home = p; CoTaskMemFree(p);
+        }
+    }
+    if (home.empty()) return L"";
+    return home + L"\\.copilot\\session-state";
+}
+
+// Trim leading/trailing ASCII whitespace (incl. CR).
+std::wstring trim_ws_w(const std::wstring& s) {
+    size_t a = 0, b = s.size();
+    while (a < b && (s[a] == L' ' || s[a] == L'\t')) ++a;
+    while (b > a && (s[b - 1] == L' ' || s[b - 1] == L'\t' || s[b - 1] == L'\r')) --b;
+    return s.substr(a, b - a);
+}
+
+// Extract a top-level scalar from a tiny one-level YAML file. Handles
+// leading whitespace, optional double/single quoted values, trailing
+// comments (when value is unquoted), and CRLF line endings.
+std::wstring read_yaml_scalar(const std::wstring& filePath, const std::wstring& key) {
+    std::string raw = read_file(filePath);
+    if (raw.empty()) return L"";
+    std::wstring text = utf8_to_wide(raw);
+
+    std::wstring needle = key + L":";
+    size_t pos = 0;
+    while (pos <= text.size()) {
+        size_t lineEnd = text.find(L'\n', pos);
+        std::wstring line = text.substr(
+            pos, lineEnd == std::wstring::npos ? std::wstring::npos : lineEnd - pos);
+        if (lineEnd == std::wstring::npos) pos = text.size() + 1;
+        else pos = lineEnd + 1;
+
+        std::wstring t = trim_ws_w(line);
+        if (t.empty() || t[0] == L'#') continue;
+        if (t.size() < needle.size()) continue;
+        if (t.compare(0, needle.size(), needle) != 0) continue;
+        std::wstring val = trim_ws_w(t.substr(needle.size()));
+        if (val.empty()) return L"";
+        if (val[0] != L'"' && val[0] != L'\'') {
+            size_t hash = val.find(L" #");
+            if (hash != std::wstring::npos) val = trim_ws_w(val.substr(0, hash));
+        }
+        if (val.size() >= 2 &&
+            ((val.front() == L'"' && val.back() == L'"') ||
+             (val.front() == L'\'' && val.back() == L'\''))) {
+            val = val.substr(1, val.size() - 2);
+        }
+        return val;
+    }
+    return L"";
+}
+
+// Validate a UUID-shaped string (8-4-4-4-12 hex + 4 dashes). Defends
+// against path traversal via a malicious sessionId.
+bool is_valid_session_id(const std::wstring& s) {
+    if (s.size() != 36) return false;
+    for (size_t i = 0; i < 36; ++i) {
+        wchar_t c = s[i];
+        if (i == 8 || i == 13 || i == 18 || i == 23) {
+            if (c != L'-') return false;
+        } else {
+            if (!((c >= L'0' && c <= L'9') ||
+                  (c >= L'a' && c <= L'f') ||
+                  (c >= L'A' && c <= L'F'))) return false;
+        }
+    }
+    return true;
+}
+
+// Look up the human-readable session name. Prefers workspace.yaml `name`,
+// falls back to `summary`, then `repository`. Returns empty on failure.
+std::wstring get_copilot_session_name(const std::wstring& sessionId) {
+    if (!is_valid_session_id(sessionId)) return L"";
+    std::wstring base = copilot_session_state_dir();
+    if (base.empty()) return L"";
+    std::wstring yaml = base + L"\\" + sessionId + L"\\workspace.yaml";
+    if (!path_exists(yaml)) return L"";
+
+    std::wstring name = read_yaml_scalar(yaml, L"name");
+    if (!name.empty()) return name;
+    name = read_yaml_scalar(yaml, L"summary");
+    if (!name.empty()) return name;
+    return read_yaml_scalar(yaml, L"repository");
+}
+
+std::wstring humanize_reason(const std::wstring& reason) {
+    if (reason == L"complete") return L"";
+    if (reason == L"error") return L"failed";
+    if (reason == L"timeout") return L"timed out";
+    if (reason == L"abort") return L"aborted";
+    if (reason == L"user_exit") return L"session ended";
+    return reason;
+}
+
+std::wstring folder_name_of(const std::wstring& cwd) {
+    if (cwd.empty()) return L"";
+    fs::path p(cwd);
+    std::wstring name = p.filename().wstring();
+    if (name.empty()) name = p.root_name().wstring();
+    return name;
+}
+
+struct CopilotEndContent {
+    std::wstring title;
+    std::wstring message;
+};
+
+CopilotEndContent build_copilot_end_content(const std::wstring& cwd,
+                                            const std::wstring& reason,
+                                            const std::wstring& prompt,
+                                            const std::wstring& sessionName) {
+    CopilotEndContent c;
+    std::wstring folder = folder_name_of(cwd);
+    std::wstring human = humanize_reason(reason);
+    bool ok = reason.empty() || reason == L"complete";
+
+    std::wstring titleSuffix;
+    if (ok) {
+        // No suffix.
+    } else if (reason == L"user_exit") {
+        titleSuffix = L"session ended";
+    } else {
+        titleSuffix = human;
+    }
+
+    if (sessionName.empty()) {
+        c.title = L"GitHub Copilot";
+        if (!titleSuffix.empty()) c.title += L" - " + titleSuffix;
+    } else {
+        c.title = L"GitHub Copilot - " + sessionName;
+        if (!titleSuffix.empty()) c.title += L" (" + titleSuffix + L")";
+    }
+
+    std::wstring shortPrompt = truncate_w(normalize_ws(prompt), 80);
+    if (!shortPrompt.empty()) {
+        c.message = L"\"" + shortPrompt + L"\"";
+        if (!folder.empty()) c.message += L" - " + folder;
+    } else {
+        std::wstring lead = ok ? L"Finished" : (human.empty() ? L"Ended" : human);
+        if (!lead.empty() && lead[0] >= L'a' && lead[0] <= L'z')
+            lead[0] = (wchar_t)(lead[0] - 32);
+        c.message = lead;
+        if (!folder.empty()) c.message += L" - " + folder;
+    }
+    // Cap total lengths defensively (sessionName/prompt are unbounded).
+    c.title   = truncate_w(c.title, 100);
+    c.message = truncate_w(c.message, 140);
+    return c;
+}
+
+struct CopilotHookResult {
+    bool shouldToast = false;
+    std::wstring title;
+    std::wstring message;
+};
+
+// Process a Copilot hook event. event must be "prompt" or "end".
+CopilotHookResult handle_copilot_hook(const std::wstring& event) {
+    CopilotHookResult r;
+    std::string raw = read_stdin_utf8();
+
+    JsonObject obj;
+    bool parsed = false;
+    if (!raw.empty()) {
+        try {
+            obj = JsonObject::Parse(to_hstring(raw));
+            parsed = true;
+        } catch (const hresult_error&) {
+            parsed = false;
+        }
+    }
+
+    auto getString = [&](const wchar_t* key) -> std::wstring {
+        if (!parsed || !obj.HasKey(key)) return L"";
+        try {
+            auto v = obj.GetNamedValue(key);
+            if (v.ValueType() == JsonValueType::String)
+                return std::wstring(v.GetString());
+        } catch (...) {}
+        return L"";
+    };
+    auto getNumber = [&](const wchar_t* key) -> uint64_t {
+        if (!parsed || !obj.HasKey(key)) return 0;
+        try {
+            auto v = obj.GetNamedValue(key);
+            if (v.ValueType() == JsonValueType::Number)
+                return (uint64_t)v.GetNumber();
+        } catch (...) {}
+        return 0;
+    };
+
+    if (event == L"prompt") {
+        std::wstring cwd = getString(L"cwd");
+        std::wstring prompt = getString(L"prompt");
+        uint64_t ts = getNumber(L"timestamp");
+        if (ts == 0) {
+            ts = (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+        }
+        cache_copilot_prompt(cwd, ts, prompt);
+        // User just submitted -> they're in the terminal. Cancel any pending
+        // idle toast for this cwd so the watchdog doesn't fire after they
+        // re-engage.
+        if (!cwd.empty()) cancel_pending(cwd);
+        return r; // shouldToast = false
+    }
+
+    if (event == L"tool") {
+        // postToolUse: a tool just finished. Refresh the pending file's
+        // fireMs to (now + idleSec*1000), snapshotting the latest cached
+        // prompt for the toast body. Then spawn a detached watchdog (which
+        // dedupes via a single-instance lock).
+        std::wstring cwd = getString(L"cwd");
+        if (cwd.empty()) return r;
+        // Read-only peek so we don't race with sessionEnd consuming the
+        // prompt cache file.
+        std::wstring prompt = peek_copilot_prompt(cwd, now_ms());
+        std::wstring sessionName = get_copilot_session_name(getString(L"sessionId"));
+        // Capture the terminal window HWND NOW, while Copilot is still our
+        // ancestor. By the time the detached watchdog fires the toast we'd
+        // no longer be reachable from the terminal via parent walk.
+        HWND termWnd = find_ancestor_window();
+        unsigned idleSec = copilot_idle_seconds();
+        uint64_t fireMs = now_ms() + (uint64_t)idleSec * 1000ULL;
+        write_pending(cwd, fireMs, prompt, sessionName, (uint64_t)(ULONG_PTR)termWnd);
+        spawn_watchdog(fnv1a_hex(cwd));
+        return r; // shouldToast = false
+    }
+
+    // event == "end" (or unknown — treat as end)
+    std::wstring cwd = getString(L"cwd");
+    std::wstring reason = getString(L"reason");
+    uint64_t endTs = getNumber(L"timestamp");
+    std::wstring prompt = consume_copilot_prompt(cwd, endTs);
+    std::wstring sessionName = get_copilot_session_name(getString(L"sessionId"));
+    if (!cwd.empty()) cancel_pending(cwd);
+    auto content = build_copilot_end_content(cwd, reason, prompt, sessionName);
+    r.shouldToast = true;
+    r.title = content.title;
+    r.message = content.message;
+    return r;
 }
 
 // Install hook for OpenAI Codex CLI
@@ -1264,11 +2082,10 @@ bool is_gemini_installed() {
 }
 
 // Check if Copilot hook is installed
-bool is_copilot_installed() {
-    std::wstring configPath = L".github\\hooks\\toasty.json";
+bool is_copilot_installed_at(const std::wstring& configPath) {
     std::string content = read_file(configPath);
     if (content.empty()) return false;
-    
+
     try {
         auto rootObj = JsonObject::Parse(to_hstring(content));
         if (rootObj.HasKey(L"hooks")) {
@@ -1289,11 +2106,20 @@ bool is_copilot_installed() {
             }
         }
     } catch (const hresult_error&) {
-        // Config exists but couldn't be parsed
         return false;
     }
-    
+
     return false;
+}
+
+bool is_copilot_installed() {
+    return is_copilot_installed_at(copilot_repo_config_path());
+}
+
+bool is_copilot_installed_global() {
+    std::wstring p = copilot_global_config_path();
+    if (p.empty()) return false;
+    return is_copilot_installed_at(p);
 }
 
 // Remove toasty hooks from a JSON array
@@ -1409,29 +2235,32 @@ bool uninstall_gemini() {
     return true;
 }
 
-// Uninstall hook for GitHub Copilot
+// Uninstall hook for GitHub Copilot. Removes both the per-repo config and
+// the user-global config (best-effort).
 bool uninstall_copilot() {
-    std::wstring configPath = L".github\\hooks\\toasty.json";
-    
-    try {
-        if (path_exists(configPath)) {
-            backup_file(configPath);
-            fs::remove(configPath);
+    bool ok = true;
+    auto removeOne = [&](const std::wstring& configPath) {
+        if (configPath.empty()) return;
+        try {
+            if (path_exists(configPath)) {
+                backup_file(configPath);
+                fs::remove(configPath);
+            }
+        } catch (const std::exception& e) {
+            ok = false;
+            int size = MultiByteToWideChar(CP_UTF8, 0, e.what(), -1, nullptr, 0);
+            if (size > 0) {
+                std::wstring wideMsg(size - 1, 0);
+                MultiByteToWideChar(CP_UTF8, 0, e.what(), -1, &wideMsg[0], size);
+                std::wcerr << L"Error uninstalling Copilot hook: " << wideMsg << L"\n";
+            } else {
+                std::wcerr << L"Error uninstalling Copilot hook\n";
+            }
         }
-    } catch (const std::exception& e) {
-        // Convert narrow string to wide string
-        int size = MultiByteToWideChar(CP_UTF8, 0, e.what(), -1, nullptr, 0);
-        if (size > 0) {
-            std::wstring wideMsg(size - 1, 0);
-            MultiByteToWideChar(CP_UTF8, 0, e.what(), -1, &wideMsg[0], size);
-            std::wcerr << L"Error uninstalling Copilot hook: " << wideMsg << L"\n";
-        } else {
-            std::wcerr << L"Error uninstalling Copilot hook\n";
-        }
-        return false;
-    }
-    
-    return true;
+    };
+    removeOne(copilot_repo_config_path());
+    removeOne(copilot_global_config_path());
+    return ok;
 }
 
 // Uninstall hook for OpenAI Codex
@@ -1485,19 +2314,20 @@ void show_status() {
     std::wcout << L"Installed hooks:\n";
     std::wcout << L"  " << (is_claude_installed() ? L"[x]" : L"[ ]") << L" Claude Code\n";
     std::wcout << L"  " << (is_gemini_installed() ? L"[x]" : L"[ ]") << L" Gemini CLI\n";
-    std::wcout << L"  " << (is_copilot_installed() ? L"[x]" : L"[ ]") << L" GitHub Copilot\n";
+    std::wcout << L"  " << (is_copilot_installed() ? L"[x]" : L"[ ]") << L" GitHub Copilot (repo: .github\\hooks\\toasty.json)\n";
+    std::wcout << L"  " << (is_copilot_installed_global() ? L"[x]" : L"[ ]") << L" GitHub Copilot (global: ~\\.copilot\\hooks\\toasty.json)\n";
     std::wcout << L"  " << (is_codex_installed() ? L"[x]" : L"[ ]") << L" OpenAI Codex\n";
 }
 
 // Handle --install command
-void handle_install(const std::wstring& agent) {
+void handle_install(const std::wstring& agent, bool global, bool noSessionEnd) {
     std::wstring exePath = get_exe_path();
-    
+
     if (exePath.empty()) {
         std::wcerr << L"Error: Could not determine toasty.exe path\n";
         return;
     }
-    
+
     bool installAll = agent.empty() || agent == L"all";
     bool explicitAgent = !installAll;  // User explicitly named an agent
     bool installClaude = installAll || agent == L"claude";
@@ -1511,8 +2341,9 @@ void handle_install(const std::wstring& agent) {
         if (installGemini) std::wcout << L" gemini";
         if (installCopilot) std::wcout << L" copilot";
         if (installCodex) std::wcout << L" codex";
+        if (global) std::wcout << L" (global)";
         std::wcout << L"\n";
-        
+
         if (installClaude) {
             std::wstring configPath = expand_env(L"%USERPROFILE%\\.claude\\settings.json");
             std::wcout << L"[dry-run] Would write: " << configPath << L"\n";
@@ -1528,9 +2359,20 @@ void handle_install(const std::wstring& agent) {
             std::wcout << L"[dry-run] Hook type: AfterAgent\n";
         }
         if (installCopilot) {
-            std::wcout << L"[dry-run] Would write: .github\\hooks\\toasty.json\n";
-            std::wcout << L"[dry-run] Hook command: toasty 'Copilot finished' -t 'GitHub Copilot'\n";
-            std::wcout << L"[dry-run] Hook type: sessionEnd\n";
+            std::wstring cpath = global ? copilot_global_config_path() : copilot_repo_config_path();
+            std::wcout << L"[dry-run] Would write: " << (cpath.empty() ? L"<unresolved>" : cpath) << L"\n";
+            if (!noSessionEnd) {
+                std::wcout << L"[dry-run] Hook command (sessionEnd): toasty --copilot-hook end\n";
+            }
+            std::wcout << L"[dry-run] Hook command (userPromptSubmitted): toasty --copilot-hook prompt\n";
+            std::wcout << L"[dry-run] Hook command (postToolUse): toasty --copilot-hook tool (idle watchdog)\n";
+            if (noSessionEnd) {
+                std::wcout << L"[dry-run] Hook type: userPromptSubmitted, postToolUse (sessionEnd skipped via --no-session-end)\n";
+            } else {
+                std::wcout << L"[dry-run] Hook type: sessionEnd, userPromptSubmitted, postToolUse\n";
+            }
+            std::wcout << L"[dry-run] Hook scope: " << (global ? L"global (user-level)" : L"repo (per-project)") << L"\n";
+            std::wcout << L"[dry-run] Idle threshold: " << copilot_idle_seconds() << L"s (TOASTY_COPILOT_IDLE_SEC)\n";
         }
         if (installCodex) {
             std::wstring configPath = expand_env(L"%USERPROFILE%\\.codex\\config.toml");
@@ -1576,10 +2418,22 @@ void handle_install(const std::wstring& agent) {
         }
     }
     
-    if (installCopilot && (copilotDetected || explicitAgent)) {
-        if (install_copilot(exePath)) {
-            std::wcout << L"  [x] GitHub Copilot: Added sessionEnd hook\n";
-            std::wcout << L"      Note: This is repo-level only, not global\n";
+    if (installCopilot && (copilotDetected || explicitAgent || global)) {
+        bool ok = global ? install_copilot_global(exePath, noSessionEnd)
+                         : install_copilot(exePath, noSessionEnd);
+        const wchar_t* hookList = noSessionEnd
+            ? L"userPromptSubmitted + postToolUse hooks (sessionEnd skipped)"
+            : L"sessionEnd + userPromptSubmitted + postToolUse hooks";
+        if (ok) {
+            if (global) {
+                std::wcout << L"  [x] GitHub Copilot: Added " << hookList << L" (global)\n";
+                std::wcout << L"      Config: " << copilot_global_config_path() << L"\n";
+                std::wcout << L"      Idle watchdog: " << copilot_idle_seconds() << L"s after last tool (override with TOASTY_COPILOT_IDLE_SEC)\n";
+            } else {
+                std::wcout << L"  [x] GitHub Copilot: Added " << hookList << L"\n";
+                std::wcout << L"      Idle watchdog: " << copilot_idle_seconds() << L"s after last tool (override with TOASTY_COPILOT_IDLE_SEC)\n";
+                std::wcout << L"      Note: This is repo-level only. Use --install copilot --global for user-wide.\n";
+            }
             anyInstalled = true;
         } else {
             std::wcout << L"  [ ] GitHub Copilot: Failed to install\n";
@@ -1638,9 +2492,9 @@ void handle_uninstall() {
         }
     }
     
-    if (is_copilot_installed()) {
+    if (is_copilot_installed() || is_copilot_installed_global()) {
         if (uninstall_copilot()) {
-            std::wcout << L"  [x] GitHub Copilot: Removed hooks\n";
+            std::wcout << L"  [x] GitHub Copilot: Removed hooks (repo + global)\n";
             anyUninstalled = true;
         } else {
             std::wcout << L"  [ ] GitHub Copilot: Failed to remove\n";
@@ -1805,9 +2659,15 @@ int wmain(int argc, wchar_t* argv[]) {
     bool doFocus = false;
     bool doRegister = false;
     std::wstring installAgent;
+    bool installGlobal = false;
+    bool noSessionEnd = false;
     bool explicitApp = false;  // Track if user explicitly set --app
     bool explicitTitle = false; // Track if user explicitly set -t
     bool debug = false;
+    std::wstring copilotHookEvent; // Set when --copilot-hook <event> is used
+    std::wstring copilotWatchdogHash; // Set when --copilot-watchdog <hash> is used
+    uint64_t launchHwnd = 0;       // Set when --launch-hwnd <decimal> is used
+    std::wstring focusUrl;         // Set when --focus <url> is used
 
     // Quick scan for --debug and --dry-run flags
     for (int i = 1; i < argc; i++) {
@@ -1855,6 +2715,24 @@ int wmain(int argc, wchar_t* argv[]) {
         }
         else if (arg == L"--focus") {
             doFocus = true;
+            // Optional next arg is the activation URL passed by Windows when
+            // the toast is clicked (e.g. "toasty://focus?hwnd=12345").
+            if (i + 1 < argc) {
+                std::wstring next = argv[i + 1];
+                if (!next.empty() && next[0] != L'-') {
+                    focusUrl = next;
+                    ++i;
+                }
+            }
+        }
+        else if (arg == L"--launch-hwnd") {
+            if (i + 1 < argc) {
+                try { launchHwnd = std::stoull(argv[++i]); }
+                catch (...) { launchHwnd = 0; }
+            } else {
+                std::wcerr << L"Error: --launch-hwnd requires a decimal HWND\n";
+                return 1;
+            }
         }
         else if (arg == L"--register") {
             doRegister = true;
@@ -1911,6 +2789,28 @@ int wmain(int argc, wchar_t* argv[]) {
                 return 1;
             }
         }
+        else if (arg == L"--global") {
+            installGlobal = true;
+        }
+        else if (arg == L"--no-session-end") {
+            noSessionEnd = true;
+        }
+        else if (arg == L"--copilot-hook") {
+            if (i + 1 < argc) {
+                copilotHookEvent = argv[++i];
+            } else {
+                std::wcerr << L"Error: --copilot-hook requires an event name (prompt|end|tool)\n";
+                return 1;
+            }
+        }
+        else if (arg == L"--copilot-watchdog") {
+            if (i + 1 < argc) {
+                copilotWatchdogHash = argv[++i];
+            } else {
+                std::wcerr << L"Error: --copilot-watchdog requires a hash argument\n";
+                return 1;
+            }
+        }
         else if (arg == L"--debug") {
             // Already handled in pre-scan
         }
@@ -1930,7 +2830,7 @@ int wmain(int argc, wchar_t* argv[]) {
 
     if (doInstall) {
         init_apartment();
-        handle_install(installAgent);
+        handle_install(installAgent, installGlobal, noSessionEnd);
         return 0;
     }
 
@@ -1945,8 +2845,27 @@ int wmain(int argc, wchar_t* argv[]) {
         // Detach from console entirely to prevent flash
         FreeConsole();
 
-        // Protocol handlers have focus restrictions - use aggressive approach
-        HWND targetWnd = get_saved_console_window_handle();
+        // Protocol handlers have focus restrictions - use aggressive approach.
+        // Prefer an HWND embedded in the activation URL (per-toast targeting,
+        // works correctly for multiple concurrent Copilot sessions). Fall back
+        // to the saved registry handle for older toasts and other apps.
+        HWND targetWnd = nullptr;
+        if (!focusUrl.empty()) {
+            size_t qpos = focusUrl.find(L"hwnd=");
+            if (qpos != std::wstring::npos) {
+                size_t start = qpos + 5;
+                size_t end = focusUrl.find_first_of(L"&#", start);
+                std::wstring v = focusUrl.substr(start, end == std::wstring::npos ? std::wstring::npos : end - start);
+                try {
+                    uint64_t h = std::stoull(v);
+                    HWND cand = (HWND)(ULONG_PTR)h;
+                    if (h != 0 && IsWindow(cand)) targetWnd = cand;
+                } catch (...) {}
+            }
+        }
+        if (!targetWnd) {
+            targetWnd = get_saved_console_window_handle();
+        }
         if (!targetWnd) {
             // Fallback: find any terminal window
             EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
@@ -1994,6 +2913,31 @@ int wmain(int argc, wchar_t* argv[]) {
         }
     }
 
+    // Watchdog mode: detached process that sleeps until the pending file's
+    // fireMs elapses, then re-invokes toasty to fire the toast. No WinRT.
+    if (!copilotWatchdogHash.empty()) {
+        return run_copilot_watchdog(copilotWatchdogHash);
+    }
+
+    // Handle Copilot hook events: read JSON payload from stdin, build a rich
+    // toast (or silently cache the prompt for later).
+    if (!copilotHookEvent.empty()) {
+        init_apartment();
+        auto res = handle_copilot_hook(copilotHookEvent);
+        if (!res.shouldToast) {
+            return 0;
+        }
+        message = res.message;
+        title = res.title;
+        explicitTitle = true;
+        // Use the copilot icon for the toast.
+        const AppPreset* p = find_preset(L"copilot");
+        if (p) {
+            std::wstring ipath = extract_icon_to_temp(p->iconResourceId);
+            if (!ipath.empty()) iconPath = ipath;
+        }
+    }
+
     if (message.empty()) {
         std::wcerr << L"Error: Message is required.\n";
         print_usage();
@@ -2011,7 +2955,16 @@ int wmain(int argc, wchar_t* argv[]) {
 
         // Save the terminal window handle for click-to-focus
         // Walk process tree to find the actual terminal/IDE window
-        HWND terminalWnd = find_ancestor_window();
+        HWND terminalWnd = nullptr;
+        if (launchHwnd != 0) {
+            // Caller (e.g. detached watchdog) explicitly passed an HWND
+            // captured at hook time. Trust it if it's still a valid window.
+            HWND cand = (HWND)(ULONG_PTR)launchHwnd;
+            if (IsWindow(cand)) terminalWnd = cand;
+        }
+        if (!terminalWnd) {
+            terminalWnd = find_ancestor_window();
+        }
 
         // Fallback: if process tree didn't find a window, search for any terminal
         if (!terminalWnd) {
@@ -2032,8 +2985,15 @@ int wmain(int argc, wchar_t* argv[]) {
             save_console_window_handle(terminalWnd);
         }
 
-        // Build toast XML with protocol activation for click-to-focus
-        std::wstring xml = L"<toast activationType=\"protocol\" launch=\"toasty://focus\"><visual><binding template=\"ToastGeneric\">";
+        // Build toast XML with protocol activation for click-to-focus.
+        // Embed HWND directly in the launch URL so concurrent toasts each
+        // target their own window (the registry-saved handle is shared).
+        std::wstring launchUrl = L"toasty://focus";
+        if (terminalWnd) {
+            launchUrl += L"?hwnd=" + std::to_wstring((uint64_t)(ULONG_PTR)terminalWnd);
+        }
+        std::wstring xml = L"<toast activationType=\"protocol\" launch=\"" +
+                           escape_xml(launchUrl) + L"\"><visual><binding template=\"ToastGeneric\">";
         
         // Add icon if provided
         if (!iconPath.empty()) {

--- a/tests/test-toasty.ps1
+++ b/tests/test-toasty.ps1
@@ -61,7 +61,8 @@ function Pass {
 function Run-Toasty {
     param(
         [string[]]$Arguments,
-        [hashtable]$Env = @{}
+        [hashtable]$Env = @{},
+        [string]$StdinInput = $null
     )
     
     $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -73,12 +74,19 @@ function Run-Toasty {
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
     $psi.CreateNoWindow = $true
+    if ($null -ne $StdinInput) {
+        $psi.RedirectStandardInput = $true
+    }
     
     foreach ($key in $Env.Keys) {
         $psi.EnvironmentVariables[$key] = $Env[$key]
     }
     
     $proc = [System.Diagnostics.Process]::Start($psi)
+    if ($null -ne $StdinInput) {
+        $proc.StandardInput.Write($StdinInput)
+        $proc.StandardInput.Close()
+    }
     $stdout = $proc.StandardOutput.ReadToEnd()
     $stderr = $proc.StandardError.ReadToEnd()
     $proc.WaitForExit(10000) # 10s timeout
@@ -193,10 +201,49 @@ Write-Host ("=" * 40)
 $r = Run-Toasty @("Hello World", "--dry-run")
 $xml = $r.Stdout
 if ((Assert-OutputContains "has toast element" $xml "activationType=`"protocol`"") -and
-    (Assert-OutputContains "has protocol launch" $xml "launch=`"toasty://focus`"") -and
+    (Assert-OutputContains "has protocol launch" $xml "launch=`"toasty://focus") -and
     (Assert-OutputContains "has message text" $xml "<text>Hello World</text>") -and
     (Assert-OutputContains "has binding" $xml "template=`"ToastGeneric`"")) {
     Pass "toast XML structure"
+}
+
+# --launch-hwnd embeds the HWND in the toast launch URL.
+# Use a real HWND (this PowerShell process's main window) so IsWindow() passes;
+# otherwise the code safely falls back to ancestor-walk.
+Add-Type -Namespace W -Name N -MemberDefinition '[DllImport("user32.dll")] public static extern System.IntPtr GetForegroundWindow();' -ErrorAction SilentlyContinue
+$realHwnd = [int64][W.N]::GetForegroundWindow()
+$r = Run-Toasty @("Hi", "--dry-run", "--launch-hwnd", "$realHwnd")
+if (Assert-OutputContains "launch URL has hwnd" $r.Stdout "launch=`"toasty://focus?hwnd=$realHwnd`"") {
+    Pass "launch-hwnd embedded in toast launch URL"
+}
+
+# Watchdog tool path stashes hwnd in pending file (best-effort: depends on
+# whether Cmder/CI environment has any visible ancestor window). Just verify
+# the field exists and is numeric.
+$pendingDir = Join-Path $env:LOCALAPPDATA "toasty\copilot-pending"
+$lhCwd = "C:\lh-test-" + ([Guid]::NewGuid().ToString("N").Substring(0,12))
+$env:TOASTY_COPILOT_IDLE_SEC = "3600"
+try {
+    $stdin = '{"timestamp":1700000000000,"cwd":"' + ($lhCwd -replace '\\','\\') + '","toolName":"bash","toolArgs":"{}"}'
+    Run-Toasty @("--copilot-hook", "tool") -StdinInput $stdin | Out-Null
+    $f = @(Get-ChildItem $pendingDir -Filter "*.json" -ErrorAction SilentlyContinue | Where-Object {
+        try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).cwd -eq $lhCwd } catch { $false }
+    })
+    if ($f.Count -eq 1) {
+        $rec = Get-Content $f[0].FullName -Raw | ConvertFrom-Json
+        if ($rec.PSObject.Properties.Name -contains "hwnd") {
+            Pass "tool hook records hwnd field in pending"
+        } else {
+            $script:failed++
+            Write-Host "  FAIL: pending file missing 'hwnd' field" -ForegroundColor Red
+        }
+        Remove-Item $f[0].FullName -Force -ErrorAction SilentlyContinue
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: tool hook did not create pending file for hwnd test" -ForegroundColor Red
+    }
+} finally {
+    Remove-Item Env:\TOASTY_COPILOT_IDLE_SEC -ErrorAction SilentlyContinue
 }
 
 # XML escaping
@@ -241,7 +288,12 @@ $r = Run-Toasty @("--install", "copilot", "--dry-run")
 if ((Assert-ExitCode "install copilot exits 0" 0 $r.ExitCode) -and
     (Assert-OutputContains "install copilot target" $r.Stdout "Install targets: copilot") -and
     (Assert-OutputContains "install copilot hook" $r.Stdout "Hook type: sessionEnd") -and
-    (Assert-OutputContains "install copilot path" $r.Stdout "toasty.json")) {
+    (Assert-OutputContains "install copilot path" $r.Stdout "toasty.json") -and
+    (Assert-OutputContains "install copilot prompt hook" $r.Stdout "userPromptSubmitted") -and
+    (Assert-OutputContains "install copilot end cmd" $r.Stdout "--copilot-hook end") -and
+    (Assert-OutputContains "install copilot prompt cmd" $r.Stdout "--copilot-hook prompt") -and
+    (Assert-OutputContains "install copilot tool cmd" $r.Stdout "--copilot-hook tool") -and
+    (Assert-OutputContains "install copilot postToolUse" $r.Stdout "postToolUse")) {
     Pass "install copilot --dry-run"
 }
 
@@ -272,6 +324,404 @@ if ((Assert-ExitCode "uninstall exits 0" 0 $r.ExitCode) -and
     (Assert-OutputContains "uninstall copilot" $r.Stdout "Copilot:") -and
     (Assert-OutputContains "uninstall codex" $r.Stdout "Codex:")) {
     Pass "uninstall --dry-run"
+}
+
+# ============================================================
+# Test Suite: Copilot hook events
+# ============================================================
+Write-Host "`nCopilot Hook Tests" -ForegroundColor Cyan
+Write-Host ("=" * 40)
+
+$copilotRepoRoot = Join-Path ([System.IO.Path]::GetTempPath()) "toasty-copilot-test-$(Get-Random)"
+$cwdEsc = $copilotRepoRoot.Replace('\', '\\')
+$folderName = Split-Path -Leaf $copilotRepoRoot
+
+# end with no stdin (manual invocation) must not hang and must show fallback
+$r = Run-Toasty @("--copilot-hook", "end", "--dry-run")
+if ((Assert-ExitCode "hook end no-stdin exits 0" 0 $r.ExitCode) -and
+    (Assert-OutputContains "hook end no-stdin title" $r.Stdout "Title: GitHub Copilot") -and
+    (Assert-OutputContains "hook end no-stdin message" $r.Stdout "Message: Finished")) {
+    Pass "copilot-hook end with no stdin (no hang, fallback)"
+}
+
+# end with garbage JSON: tolerated
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput "not json"
+if ((Assert-ExitCode "hook end garbage exits 0" 0 $r.ExitCode) -and
+    (Assert-OutputContains "hook end garbage fallback" $r.Stdout "Message: Finished")) {
+    Pass "copilot-hook end with invalid JSON"
+}
+
+# end with reason=timeout but no cached prompt
+$payload = '{"timestamp":1700000000000,"cwd":"' + $cwdEsc + '","reason":"timeout"}'
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+if ((Assert-ExitCode "hook end timeout exits 0" 0 $r.ExitCode) -and
+    (Assert-OutputContains "hook end timeout title" $r.Stdout "GitHub Copilot - timed out") -and
+    (Assert-OutputContains "hook end timeout message" $r.Stdout "Timed out - $folderName")) {
+    Pass "copilot-hook end with timeout reason"
+}
+
+# end with reason=error
+$payload = '{"timestamp":1700000000000,"cwd":"' + $cwdEsc + '","reason":"error"}'
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+if ((Assert-OutputContains "hook end error title" $r.Stdout "GitHub Copilot - failed") -and
+    (Assert-OutputContains "hook end error message" $r.Stdout "Failed - $folderName")) {
+    Pass "copilot-hook end with error reason"
+}
+
+# end with reason=user_exit
+$payload = '{"timestamp":1700000000000,"cwd":"' + $cwdEsc + '","reason":"user_exit"}'
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+if ((Assert-OutputContains "hook end user_exit title" $r.Stdout "GitHub Copilot - session ended") -and
+    (Assert-OutputContains "hook end user_exit message" $r.Stdout "Session ended - $folderName")) {
+    Pass "copilot-hook end with user_exit reason"
+}
+
+# prompt event always exits silently with no toast
+$payload = '{"timestamp":1700000000000,"cwd":"' + $cwdEsc + '","prompt":"hello"}'
+$r = Run-Toasty -Arguments @("--copilot-hook", "prompt", "--dry-run") -StdinInput $payload
+if ((Assert-ExitCode "hook prompt exits 0" 0 $r.ExitCode) -and
+    (Assert-OutputNotContains "hook prompt no toast" $r.Stdout "Toast XML")) {
+    Pass "copilot-hook prompt is silent"
+}
+
+# Round-trip: cache a prompt then end picks it up. Use a unique cwd to avoid
+# interference from other test cases.
+$rtCwd = Join-Path ([System.IO.Path]::GetTempPath()) "toasty-rt-$(Get-Random)"
+$rtCwdEsc = $rtCwd.Replace('\', '\\')
+$rtFolder = Split-Path -Leaf $rtCwd
+$promptPayload = '{"timestamp":1700000000000,"cwd":"' + $rtCwdEsc + '","prompt":"Refactor the auth module"}'
+$endPayload = '{"timestamp":1700000001000,"cwd":"' + $rtCwdEsc + '","reason":"complete"}'
+Run-Toasty -Arguments @("--copilot-hook", "prompt") -StdinInput $promptPayload | Out-Null
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $endPayload
+if ((Assert-ExitCode "hook roundtrip exits 0" 0 $r.ExitCode) -and
+    (Assert-OutputContains "hook roundtrip title" $r.Stdout "Title: GitHub Copilot") -and
+    (Assert-OutputContains "hook roundtrip prompt in msg" $r.Stdout "Refactor the auth module") -and
+    (Assert-OutputContains "hook roundtrip folder in msg" $r.Stdout $rtFolder)) {
+    Pass "copilot-hook prompt -> end round trip"
+}
+
+# Subsequent end with same cwd (cache consumed) falls back to generic message
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $endPayload
+if (Assert-OutputContains "hook cache consumed" $r.Stdout "Message: Finished - $rtFolder") {
+    Pass "copilot-hook prompt cache consumed after end"
+}
+
+# Multiline prompt is normalized to single line
+$mlPayload = '{"timestamp":1700000010000,"cwd":"' + $rtCwdEsc + '","prompt":"line one\n\nline   two\ttab"}'
+$endPayload2 = '{"timestamp":1700000011000,"cwd":"' + $rtCwdEsc + '","reason":"complete"}'
+Run-Toasty -Arguments @("--copilot-hook", "prompt") -StdinInput $mlPayload | Out-Null
+$r = Run-Toasty -Arguments @("--copilot-hook", "end", "--dry-run") -StdinInput $endPayload2
+if ((Assert-OutputContains "hook normalized prompt" $r.Stdout "line one line two tab") -and
+    (Assert-OutputNotContains "hook no newline in msg" $r.Stdout "line one`n")) {
+    Pass "copilot-hook prompt whitespace normalization"
+}
+
+# ---- Idle watchdog (postToolUse) tests ----
+# Use a unique cwd value per run so its FNV-1a hash maps to a unique pending file.
+$pendingDir = Join-Path $env:LOCALAPPDATA "toasty\copilot-pending"
+$wdCwd = "C:\watchdog-test-" + ([System.Guid]::NewGuid().ToString("N").Substring(0,12))
+$ts = [int64]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
+
+# A `tool` event creates a pending file. Use a very long idle so the watchdog
+# child won't fire during the test.
+$env:TOASTY_COPILOT_IDLE_SEC = "3600"
+try {
+    $stdin = '{"timestamp":' + $ts + ',"cwd":"' + ($wdCwd -replace '\\','\\') + '","toolName":"bash","toolArgs":"{}"}'
+    $r = Run-Toasty @("--copilot-hook", "tool") -StdinInput $stdin
+    $pendingFiles = @(Get-ChildItem $pendingDir -Filter "*.json" -ErrorAction SilentlyContinue | Where-Object {
+        try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).cwd -eq $wdCwd } catch { $false }
+    })
+    if ($pendingFiles.Count -eq 1) {
+        Pass "tool hook creates pending file"
+        $rec = Get-Content $pendingFiles[0].FullName -Raw | ConvertFrom-Json
+        $expectedFire = $ts + 3600 * 1000
+        # fireMs should be in the near future (allow generous skew for slow CI)
+        if ($rec.fireMs -ge ($ts + 3500*1000)) { Pass "tool hook sets fireMs in the future" }
+        else { $script:failed++; Write-Host "  FAIL: fireMs $($rec.fireMs) not in expected range" -ForegroundColor Red }
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: tool hook should create exactly 1 pending file, found $($pendingFiles.Count)" -ForegroundColor Red
+    }
+
+    # A `prompt` event for the same cwd cancels the pending file
+    $stdin2 = '{"timestamp":' + ($ts + 100) + ',"cwd":"' + ($wdCwd -replace '\\','\\') + '","prompt":"hello"}'
+    $r = Run-Toasty @("--copilot-hook", "prompt") -StdinInput $stdin2
+    $remaining = @(Get-ChildItem $pendingDir -Filter "*.json" -ErrorAction SilentlyContinue | Where-Object {
+        try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).cwd -eq $wdCwd } catch { $false }
+    })
+    if ($remaining.Count -eq 0) { Pass "prompt hook cancels pending watchdog" }
+    else { $script:failed++; Write-Host "  FAIL: prompt hook left $($remaining.Count) pending file(s)" -ForegroundColor Red }
+
+    # tool then end also cancels pending
+    $r = Run-Toasty @("--copilot-hook", "tool") -StdinInput $stdin
+    $stdin3 = '{"timestamp":' + ($ts + 200) + ',"cwd":"' + ($wdCwd -replace '\\','\\') + '","reason":"complete"}'
+    $r = Run-Toasty @("--copilot-hook", "end") -StdinInput $stdin3
+    $remaining = @(Get-ChildItem $pendingDir -Filter "*.json" -ErrorAction SilentlyContinue | Where-Object {
+        try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).cwd -eq $wdCwd } catch { $false }
+    })
+    if ($remaining.Count -eq 0) { Pass "end hook cancels pending watchdog" }
+    else { $script:failed++; Write-Host "  FAIL: end hook left $($remaining.Count) pending file(s)" -ForegroundColor Red }
+} finally {
+    Remove-Item Env:\TOASTY_COPILOT_IDLE_SEC -ErrorAction SilentlyContinue
+    # Clean up any straggler files from this cwd
+    Get-ChildItem $pendingDir -ErrorAction SilentlyContinue | Where-Object {
+        try {
+            $c = Get-Content $_.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+            $c.cwd -eq $wdCwd
+        } catch { $false }
+    } | Remove-Item -Force -ErrorAction SilentlyContinue
+}
+
+# ---- Session-name lookup tests ----
+# Create a fake ~/.copilot/session-state/<UUID>/workspace.yaml fixture, then
+# verify the toast title includes the session name.
+$fakeId = [Guid]::NewGuid().ToString().ToLower()
+$snStateDir = Join-Path $env:USERPROFILE ".copilot\session-state\$fakeId"
+New-Item -ItemType Directory $snStateDir -Force | Out-Null
+$snFolder = "fake-folder-$(Get-Random)"
+$snCwd = Join-Path ([System.IO.Path]::GetTempPath()) $snFolder
+$snCwdEsc = $snCwd -replace '\\','\\'
+try {
+    @"
+id: $fakeId
+cwd: $snCwd
+repository: shanselman/toasty
+branch: main
+summary: auto-generated-summary
+name: my-cool-session
+"@ | Set-Content -LiteralPath (Join-Path $snStateDir "workspace.yaml") -Encoding utf8
+
+    # end event with sessionId picks up the name
+    $payload = '{"timestamp":1700000000000,"sessionId":"' + $fakeId + '","cwd":"' + $snCwdEsc + '","reason":"complete"}'
+    $r = Run-Toasty @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+    if (Assert-OutputContains "end title has session name" $r.Stdout "GitHub Copilot - my-cool-session") {
+        Pass "session name appears in end title (complete)"
+    }
+
+    # error reason: name + parenthesized status
+    $payload = '{"timestamp":1700000000000,"sessionId":"' + $fakeId + '","cwd":"' + $snCwdEsc + '","reason":"error"}'
+    $r = Run-Toasty @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+    if (Assert-OutputContains "end title has name + reason" $r.Stdout "GitHub Copilot - my-cool-session (failed)") {
+        Pass "session name appears in end title (error)"
+    }
+
+    # Falls back to summary when name is absent
+    @"
+id: $fakeId
+cwd: $snCwd
+summary: auto-generated-summary
+"@ | Set-Content -LiteralPath (Join-Path $snStateDir "workspace.yaml") -Encoding utf8
+    $payload = '{"timestamp":1700000000000,"sessionId":"' + $fakeId + '","cwd":"' + $snCwdEsc + '","reason":"complete"}'
+    $r = Run-Toasty @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+    if (Assert-OutputContains "summary fallback" $r.Stdout "GitHub Copilot - auto-generated-summary") {
+        Pass "session name falls back to summary"
+    }
+
+    # Missing/invalid sessionId: title is unchanged "GitHub Copilot"
+    $payload = '{"timestamp":1700000000000,"cwd":"' + $snCwdEsc + '","reason":"complete"}'
+    $r = Run-Toasty @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+    if ((Assert-OutputContains "no sessionId -> plain title" $r.Stdout "Title: GitHub Copilot") -and
+        (Assert-OutputNotContains "no sessionId -> no dash suffix" $r.Stdout "GitHub Copilot - ")) {
+        Pass "missing sessionId leaves title unchanged"
+    }
+
+    # Path-traversal sessionId is rejected by validator
+    $payload = '{"timestamp":1700000000000,"sessionId":"../../../etc/passwd","cwd":"' + $snCwdEsc + '","reason":"complete"}'
+    $r = Run-Toasty @("--copilot-hook", "end", "--dry-run") -StdinInput $payload
+    if (Assert-OutputNotContains "no path traversal in title" $r.Stdout "passwd") {
+        Pass "invalid sessionId rejected"
+    }
+
+    # tool event: sessionName is persisted into the pending file
+    @"
+id: $fakeId
+cwd: $snCwd
+name: my-cool-session
+"@ | Set-Content -LiteralPath (Join-Path $snStateDir "workspace.yaml") -Encoding utf8
+    $env:TOASTY_COPILOT_IDLE_SEC = "3600"
+    try {
+        $snToolCwd = "C:\sn-tool-test-" + ([Guid]::NewGuid().ToString("N").Substring(0,12))
+        $stdin = '{"timestamp":1700000000000,"sessionId":"' + $fakeId + '","cwd":"' + ($snToolCwd -replace '\\','\\') + '","toolName":"bash","toolArgs":"{}"}'
+        Run-Toasty @("--copilot-hook", "tool") -StdinInput $stdin | Out-Null
+        $f = @(Get-ChildItem (Join-Path $env:LOCALAPPDATA "toasty\copilot-pending") -Filter "*.json" -ErrorAction SilentlyContinue | Where-Object {
+            try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).cwd -eq $snToolCwd } catch { $false }
+        })
+        if ($f.Count -eq 1) {
+            $rec = Get-Content $f[0].FullName -Raw | ConvertFrom-Json
+            if ($rec.sessionName -eq "my-cool-session") {
+                Pass "tool hook stashes sessionName in pending file"
+            } else {
+                $script:failed++
+                Write-Host "  FAIL: pending sessionName = '$($rec.sessionName)', expected 'my-cool-session'" -ForegroundColor Red
+            }
+            Remove-Item $f[0].FullName -Force -ErrorAction SilentlyContinue
+        } else {
+            $script:failed++
+            Write-Host "  FAIL: tool hook with sessionId did not create pending file" -ForegroundColor Red
+        }
+    } finally {
+        Remove-Item Env:\TOASTY_COPILOT_IDLE_SEC -ErrorAction SilentlyContinue
+    }
+} finally {
+    Remove-Item -LiteralPath $snStateDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Real install in a temp dir produces both hooks; idempotent
+$tmpRepo = Join-Path ([System.IO.Path]::GetTempPath()) "toasty-cpt-install-$(Get-Random)"
+New-Item -ItemType Directory $tmpRepo | Out-Null
+Push-Location $tmpRepo
+try {
+    & $ExePath --install copilot 2>&1 | Out-Null
+    & $ExePath --install copilot 2>&1 | Out-Null
+    $cfg = Get-Content (Join-Path $tmpRepo ".github\hooks\toasty.json") -Raw | ConvertFrom-Json
+    $seCount = @($cfg.hooks.sessionEnd).Count
+    $upsCount = @($cfg.hooks.userPromptSubmitted).Count
+    $ptuCount = @($cfg.hooks.postToolUse).Count
+    if ($seCount -ne 1) {
+        $script:failed++
+        Write-Host "  FAIL: install idempotent sessionEnd count = $seCount, expected 1" -ForegroundColor Red
+    } elseif ($upsCount -ne 1) {
+        $script:failed++
+        Write-Host "  FAIL: install idempotent userPromptSubmitted count = $upsCount, expected 1" -ForegroundColor Red
+    } elseif ($ptuCount -ne 1) {
+        $script:failed++
+        Write-Host "  FAIL: install idempotent postToolUse count = $ptuCount, expected 1" -ForegroundColor Red
+    } elseif ($cfg.hooks.sessionEnd[0].bash -notmatch '--copilot-hook end') {
+        $script:failed++
+        Write-Host "  FAIL: sessionEnd bash command wrong: $($cfg.hooks.sessionEnd[0].bash)" -ForegroundColor Red
+    } elseif ($cfg.hooks.userPromptSubmitted[0].bash -notmatch '--copilot-hook prompt') {
+        $script:failed++
+        Write-Host "  FAIL: userPromptSubmitted bash command wrong" -ForegroundColor Red
+    } elseif ($cfg.hooks.postToolUse[0].bash -notmatch '--copilot-hook tool') {
+        $script:failed++
+        Write-Host "  FAIL: postToolUse bash command wrong: $($cfg.hooks.postToolUse[0].bash)" -ForegroundColor Red
+    } else {
+        Pass "install copilot is idempotent (real fs)"
+    }
+} finally {
+    Pop-Location
+    Remove-Item -Recurse -Force $tmpRepo -ErrorAction SilentlyContinue
+}
+
+# ============================================================
+# Test Suite: Copilot Global Install
+# ============================================================
+Write-Host "`nCopilot Global Install Tests" -ForegroundColor Cyan
+Write-Host ("=" * 40)
+
+# Dry-run --global shows global path and scope
+$r = Run-Toasty @("--install", "copilot", "--global", "--dry-run") -Env @{ USERPROFILE = "C:\fake-home" }
+if (Assert-OutputContains "global dry-run shows global path" $r.Stdout "C:\fake-home\.copilot\hooks\toasty.json") { Pass "global dry-run shows global path" }
+if (Assert-OutputContains "global dry-run shows scope label" $r.Stdout "global (user-level)") { Pass "global dry-run shows scope label" }
+
+# Dry-run without --global stays repo-scoped
+$r = Run-Toasty @("--install", "copilot", "--dry-run")
+if (Assert-OutputContains "repo dry-run scope label" $r.Stdout "repo (per-project)") { Pass "repo dry-run scope label" }
+if (Assert-OutputContains "repo dry-run path" $r.Stdout ".github\hooks\toasty.json") { Pass "repo dry-run path" }
+if (Assert-OutputNotContains "repo dry-run hides global path" $r.Stdout ".copilot\hooks\toasty.json") { Pass "repo dry-run hides global path" }
+
+# Real install with --global to a temp HOME, then verify file + idempotent re-install
+$tmpHome = Join-Path $env:TEMP ("toasty-fakehome-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory $tmpHome -Force | Out-Null
+$tmpRepo = Join-Path $env:TEMP ("toasty-globalrepo-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory $tmpRepo -Force | Out-Null
+$prevCwd = Get-Location
+try {
+    Set-Location $tmpRepo
+    $globalCfg = Join-Path $tmpHome ".copilot\hooks\toasty.json"
+
+    $r = Run-Toasty @("--install", "copilot", "--global") -Env @{ USERPROFILE = $tmpHome }
+    if (Assert-OutputContains "global install reports success" $r.Stdout "Added sessionEnd + userPromptSubmitted + postToolUse hooks (global)") { Pass "global install reports success" }
+    if (Test-Path $globalCfg) { Pass "global install creates ~/.copilot/hooks/toasty.json" }
+    else { $script:failed++; $script:errors += "FAIL: global install did not create file"; Write-Host "  FAIL: global install did not create file" -ForegroundColor Red }
+
+    # File contains both hook events
+    $cfgContent = Get-Content $globalCfg -Raw
+    if ($cfgContent -match "sessionEnd" -and $cfgContent -match "userPromptSubmitted") { Pass "global config has both hook events" }
+    else { $script:failed++; $script:errors += "FAIL: global config missing hooks"; Write-Host "  FAIL: global config missing hooks" -ForegroundColor Red }
+
+    # Idempotent: re-install should not duplicate entries
+    $r = Run-Toasty @("--install", "copilot", "--global") -Env @{ USERPROFILE = $tmpHome }
+    $cfgContent2 = Get-Content $globalCfg -Raw
+    $endCount = ([regex]::Matches($cfgContent2, "sessionEnd")).Count
+    $promptCount = ([regex]::Matches($cfgContent2, "userPromptSubmitted")).Count
+    if ($endCount -eq 1 -and $promptCount -eq 1) { Pass "global re-install is idempotent" }
+    else { $script:failed++; $script:errors += "FAIL: global re-install duplicated entries (sessionEnd=$endCount, userPromptSubmitted=$promptCount)"; Write-Host "  FAIL: global re-install duplicated" -ForegroundColor Red }
+
+    # Status surfaces global install
+    $r = Run-Toasty @("--status") -Env @{ USERPROFILE = $tmpHome }
+    if (Assert-OutputContains "status shows global hook" $r.Stdout "[x] GitHub Copilot (global") { Pass "status shows global hook" }
+
+    # Uninstall removes global file even when no repo file exists
+    $r = Run-Toasty @("--uninstall") -Env @{ USERPROFILE = $tmpHome }
+    if (Assert-OutputContains "uninstall reports copilot removal" $r.Stdout "GitHub Copilot: Removed hooks") { Pass "uninstall reports copilot removal" }
+    if (-not (Test-Path $globalCfg)) { Pass "uninstall removes global config" }
+    else { $script:failed++; $script:errors += "FAIL: uninstall left global config behind"; Write-Host "  FAIL: uninstall left global config" -ForegroundColor Red }
+} finally {
+    Set-Location $prevCwd
+    Remove-Item -Recurse -Force $tmpHome -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $tmpRepo -ErrorAction SilentlyContinue
+}
+
+# Help text mentions --global
+$r = Run-Toasty @("--help")
+if (Assert-OutputContains "help mentions --global" $r.Stdout "--global") { Pass "help mentions --global" }
+if (Assert-OutputContains "help mentions --no-session-end" $r.Stdout "--no-session-end") { Pass "help mentions --no-session-end" }
+
+# --no-session-end skips sessionEnd: dry-run
+$r = Run-Toasty @("--install", "copilot", "--global", "--no-session-end", "--dry-run")
+if ((Assert-OutputContains "dry-run lists tool+prompt without sessionEnd" $r.Stdout "userPromptSubmitted, postToolUse") -and
+    (Assert-OutputNotContains "dry-run skips sessionEnd command" $r.Stdout "Hook command (sessionEnd)")) {
+    Pass "--no-session-end dry-run skips sessionEnd"
+}
+
+# --no-session-end on real install actually omits sessionEnd from JSON,
+# and re-installing without the flag adds it back. Use a fresh tmp HOME.
+$tmpHome = Join-Path ([System.IO.Path]::GetTempPath()) "toasty-nse-$(Get-Random)"
+New-Item -ItemType Directory $tmpHome | Out-Null
+$prevHome = $env:USERPROFILE
+$env:USERPROFILE = $tmpHome
+try {
+    & $ExePath --install copilot --global --no-session-end 2>&1 | Out-Null
+    $cfgPath = Join-Path $tmpHome ".copilot\hooks\toasty.json"
+    $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+    if (-not ($cfg.hooks.PSObject.Properties.Name -contains "sessionEnd")) {
+        Pass "--no-session-end omits sessionEnd from config"
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: sessionEnd present despite --no-session-end" -ForegroundColor Red
+    }
+    if (@($cfg.hooks.userPromptSubmitted).Count -eq 1 -and
+        @($cfg.hooks.postToolUse).Count -eq 1) {
+        Pass "--no-session-end keeps prompt + tool hooks"
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: --no-session-end should still install prompt + tool hooks" -ForegroundColor Red
+    }
+
+    # Re-installing WITHOUT the flag puts sessionEnd back.
+    & $ExePath --install copilot --global 2>&1 | Out-Null
+    $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+    if (@($cfg.hooks.sessionEnd).Count -eq 1 -and
+        @($cfg.hooks.userPromptSubmitted).Count -eq 1) {
+        Pass "re-install without --no-session-end restores sessionEnd"
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: re-install did not restore sessionEnd" -ForegroundColor Red
+    }
+
+    # Re-installing WITH the flag again removes the previously-added sessionEnd.
+    & $ExePath --install copilot --global --no-session-end 2>&1 | Out-Null
+    $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+    if (-not ($cfg.hooks.PSObject.Properties.Name -contains "sessionEnd")) {
+        Pass "--no-session-end on re-install strips existing sessionEnd"
+    } else {
+        $script:failed++
+        Write-Host "  FAIL: --no-session-end did not strip existing sessionEnd" -ForegroundColor Red
+    }
+} finally {
+    $env:USERPROFILE = $prevHome
+    Remove-Item -Recurse -Force $tmpHome -ErrorAction SilentlyContinue
 }
 
 # ============================================================


### PR DESCRIPTION
…ssion names

Big upgrade to `--install copilot`. The default install now writes three hook entries (`sessionEnd`, `userPromptSubmitted`, `postToolUse`) and toasts are far more informative.

Major changes:

* `--copilot-hook end|prompt|tool` modes that read Copilot CLI's hook JSON from stdin and produce rich toasts. The user prompt is cached per-cwd at `%LOCALAPPDATA%\toasty\copilot-prompts` and woven into the end toast (e.g. `GitHub Copilot - "Refactor the auth module" - myrepo`) with reason-specific titles (`complete`, `timeout`, `error`, `abort`, `user_exit`).

* `--global` install flag: writes to `~/.copilot/hooks/toasty.json` so Copilot CLI fires the hook regardless of current directory. `--uninstall` removes both repo and global locations; `--status` shows both.

* Per-turn idle watchdog (workaround for github/copilot-cli#1128): the `postToolUse` hook arms a debounced timer (default 6s, override with `TOASTY_COPILOT_IDLE_SEC`). When no new tool fires for the idle window, a detached watchdog process emits a `GitHub Copilot - ready` toast. New prompts and session end cancel the pending toast. Single-instance per-cwd via `FILE_FLAG_DELETE_ON_CLOSE` lock.

* Session-name lookup: when the hook payload includes `sessionId` (newer Copilot CLI builds — confirmed from on-disk events.jsonl logs), toasty reads `%USERPROFILE%\.copilot\session-state\<id>\workspace.yaml` and weaves the `name` (or `summary`, then `repository`) field into the toast title — handy for distinguishing notifications from multiple concurrent Copilot sessions. UUID validation guards against path traversal.

* Click-to-focus the originating terminal window: HWND is captured at hook time (while Copilot is still our ancestor), stashed in the pending JSON, and embedded in the toast activation URL as `toasty://focus?hwnd=<n>`. `--focus` parses the URL and brings that exact window to the foreground — works correctly across multiple concurrent Copilot sessions in different terminal windows. Falls back to the registry-saved HWND for non-Copilot toasts. Caveat: focuses the WT *window*, not a specific tab inside it (no public API).

* New `--no-session-end` install flag: skip the `sessionEnd` hook for users who only want per-turn notifications. Re-running with the flag also strips a previously installed entry; without it restores it. Other (non-toasty) sessionEnd entries are preserved.

* Bug fix: `postToolUse` previously consumed the prompt cache file and re-cached it, racing with sessionEnd. Replaced with a read-only `peek_copilot_prompt` helper so both hook paths can read the cache safely.

* Defensive caps: title and message lengths are capped at 100/140 chars, embedded `"` chars are stripped from inputs to the watchdog re-exec command line.

Tests: 67 total (was 22), all passing. New coverage for hook round-tripping, watchdog file lifecycle, global install, session-name lookup, click-to-focus URL embedding, and `--no-session-end` semantics.